### PR TITLE
Dev: Ruff config + VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit",
+      "source.organizeImports": "explicit"
+    },
+    "ruff.lint.enable": true,
+    "ruff.format.enable": true
+  }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+src = ["scripts"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+# ignore = []


### PR DESCRIPTION
Add VS Code Ruff settings and minimal pyproject.toml Ruff config to mirror CI (ruff check scripts).