### PR TITLE
fix(dashboard): use crop baseline for historical chart instead of sel…

### DIFF
--- a/scripts/dashboard/current_project_dashboard_v2.py
+++ b/scripts/dashboard/current_project_dashboard_v2.py
@@ -1281,10 +1281,14 @@ DASHBOARD_TEMPLATE = """
                 if (data.historical_timeline) {
                     const labels = data.historical_timeline.map(p => p.name);
                     const rates = data.historical_timeline.map(p => p.rate);
-                    const baselineSel = (data.baseline && data.baseline.selection) ? data.baseline.selection.avg_rate : 0;
+                    // Use crop baseline (most relevant for productivity comparison)
+                    // Fall back to selection if crop unavailable
+                    const baseline = (data.baseline && data.baseline.crop && data.baseline.crop.avg_rate > 0)
+                        ? data.baseline.crop.avg_rate
+                        : (data.baseline && data.baseline.selection) ? data.baseline.selection.avg_rate : 0;
                     const colors = rates.map(r =>
-                        r > baselineSel * 1.1 ? '#51cf66' :
-                        r < baselineSel * 0.9 ? '#ff6b6b' : '#4f9dff'
+                        r > baseline * 1.1 ? '#51cf66' :
+                        r < baseline * 0.9 ? '#ff6b6b' : '#4f9dff'
                     );
                     if (window.Chart) {
                         new Chart(document.getElementById('historyChart'), {
@@ -1296,8 +1300,8 @@ DASHBOARD_TEMPLATE = """
                                     data: rates,
                                     backgroundColor: colors
                                 }, {
-                                    label: 'Baseline',
-                                    data: Array(labels.length).fill(baselineSel),
+                                    label: 'Baseline (Crop)',
+                                    data: Array(labels.length).fill(baseline),
                                     type: 'line',
                                     borderColor: '#ffd43b',
                                     borderDash: [5, 5],


### PR DESCRIPTION
…ection

The historical productivity chart was using the selection baseline (which is often N/A) for the comparison line and color coding. This caused:
- Dotted baseline line at 0 (bottom of chart)
- No meaningful color coding of bars

Changes:
- Use crop baseline (126.2 img/h) for historical chart comparisons
- Fall back to selection baseline if crop unavailable
- Update label to "Baseline (Crop)" for clarity
- Now bars will be color-coded correctly:
  - Green: >10% above crop baseline
  - Red: <10% below crop baseline
  - Blue: within ±10% of baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## PR Summary

- Title: <concise, action-oriented>
- Branch: <feature/..., fix/..., chore/...>
- Linked Issue (if any): #

## What Changed
- <≤80-char bullet>
- <≤80-char bullet>
- <≤80-char bullet>

## Commits
- <short-sha> (<full-sha>): <one-line summary>

## Files Touched
- `path/to/file1`
- `path/to/file2`

## How to Verify
1. <exact command or URL>
2. <expected output>
3. <where to look>

## Links
- Direct PR: <this page URL>
- Compare view (optional): https://github.com/<org>/<repo>/compare/main...<branch>

## Reviewer Notes
- Breaking changes? <yes/no>
- Data migration? <yes/no>
- Safety concerns? <yes/no>


