### PR TITLE
Generalize backfill scripts and update documentation

### DIFF
--- a/Documents/archives/ai/AI_TRAINING_PLAYBOOK.md
+++ b/Documents/archives/ai/AI_TRAINING_PLAYBOOK.md
@@ -49,8 +49,16 @@ python3 scripts/ai/train_crop_model.py --db data/training/ai_training_decisions/
 ```
 - Validate: IoU/center distance; analyze by stage.
 
-### 4) Backfill (optional)
-- Convert legacy CSVs to v3 SQLite; keep originals; write NEW `.db` files.
+### 4) Backfill (if needed)
+
+**Current Process (Oct 31, 2025):** Use 3-phase backfill to reconstruct complete training data:
+- Phase 1A: Generate AI predictions from original images
+- Phase 1B: Extract user ground truth from physical cropped images
+- Phase 2: Merge with existing database
+
+See: `Documents/guides/BACKFILL_QUICK_START.md`
+
+Key: Physical images are source of truth. Never copy AI predictions as user ground truth.
 
 ## Cost Controls
 - Batch reads; avoid loading entire trees at once.

--- a/Documents/archives/misc/BACKFILL_QUICK_START.md
+++ b/Documents/archives/misc/BACKFILL_QUICK_START.md
@@ -1,5 +1,25 @@
 # Historical Backfill - Quick Start Guide
-**Status:** Active
+
+**⚠️ OBSOLETE ⚠️**
+
+**This guide is outdated. See the current guide at:**
+`Documents/guides/BACKFILL_QUICK_START.md`
+
+**Current process (Oct 31, 2025):**
+- Phase 1A: Generate AI predictions by running models on original images
+- Phase 1B: Extract user ground truth from physical cropped images  
+- Phase 2: Intelligently merge temp database with real database
+
+**This old guide references:**
+- CSV files (no longer used)
+- `timesheet.csv` (no longer used for backfill)
+- `backfill_v3_from_archives.py` (replaced by 3-phase scripts)
+
+---
+
+# ARCHIVED CONTENT BELOW (FOR REFERENCE ONLY)
+
+**Status:** OBSOLETE
 **Audience:** Developers
 
 **Last Updated:** 2025-10-26
@@ -29,31 +49,14 @@ stat -f "%Sm" -t "%Y-%m-%d" "training data/ProjectName_final/"*.png | sort -u
 
 ### Step 2: Run Backfill
 ```bash
-# Dry-run first
 python3 scripts/tools/backfill_v3_from_archives.py ProjectName
-
-# If looks good, execute
-python3 scripts/tools/backfill_v3_from_archives.py ProjectName --execute
 ```
 
-### Step 3: Verify Results
+### Step 3: Validate Results
 ```bash
-# Check crop variety (should NOT all be [0,0,1,1])
 sqlite3 data/training/ai_training_decisions/ProjectName.db \
   "SELECT final_crop_coords, COUNT(*) FROM ai_decisions WHERE user_action='crop' GROUP BY final_crop_coords;"
 ```
 
-## 📂 Key Files
-- **Script:** `scripts/tools/backfill_v3_from_archives.py`
-- **Full handoff:** `Documents/HANDOFF_HISTORICAL_BACKFILL_2025-10-22.md`
-- **Test data:** `training data/Aiko_raw/` and `training data/Aiko_raw_final/`
-- **Questionable DB:** `data/training/ai_training_decisions/Aiko_raw.db`
-
-## ❓ Ask Erik
-1. Is Aiko_raw data valid despite timestamp mismatch?
-2. Where are the actual cropped images stored in archives?
-3. Which historical projects should we prioritize?
-
----
-**Status:** Paused - need data validation before continuing
-
+## Related
+- `archives/sessions/2025-10-22/HANDOFF_HISTORICAL_BACKFILL_2025-10-22.md`

--- a/Documents/archives/misc/HANDOFF_HISTORICAL_BACKFILL_2025-10-22.md
+++ b/Documents/archives/misc/HANDOFF_HISTORICAL_BACKFILL_2025-10-22.md
@@ -1,4 +1,24 @@
 # Handoff Notes - Historical Backfill Project
+
+**⚠️ OBSOLETE - See New Process Below ⚠️**
+
+**This document describes an OLD approach to backfilling that has been replaced.**
+
+**Current Process (Oct 31, 2025):** See `Documents/guides/BACKFILL_QUICK_START.md` for the new 3-phase backfill process:
+- Phase 1A: Generate AI predictions by running models on original images
+- Phase 1B: Extract user ground truth from physical cropped images via template matching
+- Phase 2: Intelligently merge temp database with real database
+
+**Key differences from this old approach:**
+- No longer uses CSV files or timesheet.csv
+- Uses SQLite databases exclusively
+- Separates AI predictions from user ground truth
+- Preserves timestamps from real database
+- Supports incremental backfilling (adds to existing data)
+
+---
+
+# ARCHIVED CONTENT BELOW (FOR REFERENCE ONLY)
 **Audience:** Developers
 
 **Last Updated:** 2025-10-26
@@ -17,7 +37,7 @@ Extract v3 training data from historical project archives by comparing original 
 ## ✅ WHAT'S BEEN COMPLETED
 
 ### 1. Created Backfill Script
-**File:** `/Users/eriksjaastad/projects/Eros Mate/scripts/tools/backfill_v3_from_archives.py`
+**File:** `<project-root>/scripts/tools/backfill_v3_from_archives.py`
 
 **What it does:**
 - Takes project name (e.g., "Aiko_raw") from timesheet
@@ -130,12 +150,12 @@ if project_date not in final_mod_dates:
 ## 📂 FILE LOCATIONS
 
 ### Key Files
-- **Backfill script:** `/Users/eriksjaastad/projects/Eros Mate/scripts/tools/backfill_v3_from_archives.py`
-- **Timesheet:** `/Users/eriksjaastad/projects/Eros Mate/data/timesheet.csv`
+- **Backfill script:** `<project-root>/scripts/tools/backfill_v3_from_archives.py`
+- **Timesheet:** `<project-root>/data/timesheet.csv`
 - **Current test data:**
-  - Originals: `/Users/eriksjaastad/projects/Eros Mate/training data/Aiko_raw/`
-  - Finals: `/Users/eriksjaastad/projects/Eros Mate/training data/Aiko_raw_final/`
-- **Created database:** `/Users/eriksjaastad/projects/Eros Mate/data/training/ai_training_decisions/Aiko_raw.db` (156 KB)
+  - Originals: `<project-root>/training data/Aiko_raw/`
+  - Finals: `<project-root>/training data/Aiko_raw_final/`
+- **Created database:** `<project-root>/data/training/ai_training_decisions/Aiko_raw.db` (156 KB)
 
 ### Shared Utilities Used
 - `scripts/utils/companion_file_utils.py`:
@@ -224,7 +244,7 @@ Matches current v3 format:
 - `user_action`: 'crop' or 'approve'
 - `final_crop_coords`: JSON array or NULL
 - `user_selected_index`: Which image in group was chosen (0-3)
-- Full schema in: `/Users/eriksjaastad/projects/Eros Mate/data/schema/ai_training_decisions_v3.sql`
+- Full schema in: `<project-root>/data/schema/ai_training_decisions_v3.sql`
 
 ---
 

--- a/Documents/archives/sessions/2025-10-22/HANDOFF_HISTORICAL_BACKFILL_2025-10-22.md
+++ b/Documents/archives/sessions/2025-10-22/HANDOFF_HISTORICAL_BACKFILL_2025-10-22.md
@@ -1,11 +1,32 @@
 # Handoff Notes - Historical Backfill Project
+
+**⚠️ OBSOLETE - See New Process Below ⚠️**
+
+**This document describes an OLD approach to backfilling that has been replaced.**
+
+**Current Process (Oct 31, 2025):** See `Documents/guides/BACKFILL_QUICK_START.md` for the new 3-phase backfill process:
+- Phase 1A: Generate AI predictions by running models on original images
+- Phase 1B: Extract user ground truth from physical cropped images via template matching
+- Phase 2: Intelligently merge temp database with real database
+
+**Key differences from this old approach:**
+- No longer uses CSV files or timesheet.csv
+- Uses SQLite databases exclusively
+- Separates AI predictions from user ground truth
+- Preserves timestamps from real database
+- Supports incremental backfilling (adds to existing data)
+
+---
+
+# ARCHIVED CONTENT BELOW (FOR REFERENCE ONLY)
+
 **Audience:** Developers
 
 **Last Updated:** 2025-10-26
 
 **Date:** 2025-10-22  
 **From:** Claude (Sonnet 4.5)  
-**Status:** In Progress - Data Validation Issue Found
+**Status:** OBSOLETE - REPLACED BY NEW 3-PHASE PROCESS
 
 ---
 
@@ -17,7 +38,7 @@ Extract v3 training data from historical project archives by comparing original 
 ## ✅ WHAT'S BEEN COMPLETED
 
 ### 1. Created Backfill Script
-**File:** `/Users/eriksjaastad/projects/Eros Mate/scripts/tools/backfill_v3_from_archives.py`
+**File:** `<project-root>/scripts/tools/backfill_v3_from_archives.py`
 
 **What it does:**
 - Takes project name (e.g., "Aiko_raw") from timesheet
@@ -130,12 +151,12 @@ if project_date not in final_mod_dates:
 ## 📂 FILE LOCATIONS
 
 ### Key Files
-- **Backfill script:** `/Users/eriksjaastad/projects/Eros Mate/scripts/tools/backfill_v3_from_archives.py`
-- **Timesheet:** `/Users/eriksjaastad/projects/Eros Mate/data/timesheet.csv`
+- **Backfill script:** `<project-root>/scripts/tools/backfill_v3_from_archives.py`
+- **Timesheet:** `<project-root>/data/timesheet.csv`
 - **Current test data:**
-  - Originals: `/Users/eriksjaastad/projects/Eros Mate/training data/Aiko_raw/`
-  - Finals: `/Users/eriksjaastad/projects/Eros Mate/training data/Aiko_raw_final/`
-- **Created database:** `/Users/eriksjaastad/projects/Eros Mate/data/training/ai_training_decisions/Aiko_raw.db` (156 KB)
+  - Originals: `<project-root>/training data/Aiko_raw/`
+  - Finals: `<project-root>/training data/Aiko_raw_final/`
+- **Created database:** `<project-root>/data/training/ai_training_decisions/Aiko_raw.db` (156 KB)
 
 ### Shared Utilities Used
 - `scripts/utils/companion_file_utils.py`:
@@ -224,7 +245,7 @@ Matches current v3 format:
 - `user_action`: 'crop' or 'approve'
 - `final_crop_coords`: JSON array or NULL
 - `user_selected_index`: Which image in group was chosen (0-3)
-- Full schema in: `/Users/eriksjaastad/projects/Eros Mate/data/schema/ai_training_decisions_v3.sql`
+- Full schema in: `<project-root>/data/schema/ai_training_decisions_v3.sql`
 
 ---
 

--- a/Documents/core/CURRENT_TODO_LIST.md
+++ b/Documents/core/CURRENT_TODO_LIST.md
@@ -16,6 +16,56 @@
   - **Action:** Identify affected items → recompute from source images/sidecars → validate → write to SQLite v3 → snapshot
   - **Output:** Verified updates in `data/training/ai_training_decisions/*.db` and daily snapshot
 
+- [ ] **Generalize mojo3 backfill scripts for any project** [PRIORITY: MEDIUM]
+  - **Current Scripts:**
+    - `scripts/ai/backfill_mojo3_phase1a_ai_predictions.py` (AI predictions from originals)
+    - `scripts/ai/backfill_mojo3_phase1b_user_data.py` (User selections/crops from finals)
+  - **Action:**
+    - Accept command-line arguments for any original directory and final directory
+    - Rename scripts to remove "mojo3" prefix (e.g., `backfill_project_phase1a_ai_predictions.py`)
+    - Update to work with any project structure, not just mojo3
+  - **Benefit:** Reuse for mojo1, mojo2, or any future project backfills
+
+- [x] **Update and clean up backfill documentation** [PRIORITY: HIGH] ✅ **COMPLETED Oct 31, 2025**
+  - **Completed Actions:**
+    - ✅ Created comprehensive new guide: `Documents/guides/BACKFILL_QUICK_START.md`
+    - ✅ Documents new 3-phase process (1A: AI predictions, 1B: User ground truth, Phase 2: Merge)
+    - ✅ Marked old docs as OBSOLETE with pointers to new process:
+      - `Documents/archives/sessions/2025-10-22/HANDOFF_HISTORICAL_BACKFILL_2025-10-22.md`
+      - `Documents/archives/misc/HANDOFF_HISTORICAL_BACKFILL_2025-10-22.md`
+      - `Documents/archives/misc/BACKFILL_QUICK_START.md`
+    - ✅ Removed all CSV/timesheet references from current documentation
+    - ✅ Emphasized: Physical images are source of truth, never copy AI predictions as user data
+    - ✅ Explained user_action semantics (approve/crop/reject, NO 'skip')
+    - ✅ Documented coordinate tolerances (2% for approve detection, 1% for comparison, 5% for metrics)
+    - ✅ Included real example: mojo3 backfill with actual numbers and results
+
+- [ ] **Backfill AI predictions for historical projects** [PRIORITY: MEDIUM]
+  - **Goal:** Generate AI predictions for mojo1 and mojo2 projects to expand training data and measure AI improvement over time
+  - **Why This Is Valuable:**
+    - We have thousands of user decisions (ground truth) in mojo1/mojo2 databases
+    - We DON'T have AI predictions for those decisions (AI system didn't exist then)
+    - Running current AI models on those historical images would create:
+      - Selection match data: Did AI pick what user picked?
+      - Crop match data: Was AI's crop close to user's crop?
+      - Confidence calibration: How confident was AI when right vs wrong?
+    - This would give us 10,000+ AI-vs-user comparisons for training analysis
+  - **Process:**
+    - Use Phase 1A approach: Run ranker + crop proposer on original images
+    - Create temp database with AI predictions
+    - Compare with real database (which has user ground truth)
+    - Add AI prediction columns WITHOUT touching user data
+    - Analyze: How would current AI have performed on historical projects?
+  - **Benefits:**
+    - Measure AI improvement: "On mojo1, AI would have been 45% accurate. On mojo3, it's 54%!"
+    - More training data for model improvements
+    - Identify patterns: What types of images does AI struggle with?
+    - Better confidence calibration
+  - **Projects to Process:**
+    - mojo1 (if original images still accessible)
+    - mojo2 (if original images still accessible)
+  - **Status:** Add to backlog after mojo3 backfill complete
+
 ### TODO Hygiene
 
 - [ ] **Review and prune this TODO list** [PRIORITY: HIGH]

--- a/Documents/guides/BACKFILL_QUICK_START.md
+++ b/Documents/guides/BACKFILL_QUICK_START.md
@@ -1,53 +1,300 @@
-# Historical Backfill - Quick Start Guide
+# Backfill Training Data - Complete Guide
 
-**Last Updated:** 2025-10-26
-**Status:** Active
+**Status:** Active (Updated 2025-10-31)
 **Audience:** Developers, Operators
-**Estimated Reading Time:** 6 minutes
+**Estimated Reading Time:** 12 minutes
 
-## Goal
-Extract v3 training data from historical project archives by matching cropped images back to originals (vision-based), with strict validation.
+## Overview
 
-## Workflow
+This guide describes the **3-phase backfill process** for reconstructing complete training data (AI predictions + user ground truth) from historical projects. The process uses physical images as the source of truth, extracting crop coordinates via template matching.
 
-### 1) Validate Project
+**Key Principle:** Physical images are ALWAYS the source of truth. We NEVER copy AI predictions as user ground truth.
+
+## When to Use
+
+- **Scenario 1:** Reconstruct lost data (e.g., database not created during actual work)
+- **Scenario 2:** Fill gaps in existing databases (missing AI predictions or user data)
+- **Scenario 3:** Backfill AI predictions for historical projects (to measure AI improvement over time)
+
+## The 3-Phase Process
+
+### Phase 1A: Generate AI Predictions
+
+**Purpose:** Run current AI models on original images to recreate what the AI would have predicted.
+
+**Input:**
+- Original images directory (e.g., `/Volumes/T7Shield/Eros/original/mojo3`)
+- Trained AI models (`ranker_v3_w10.pt`, `crop_proposer_v2.pt`)
+
+**Output:**
+- Temporary database with AI predictions: `{project_id}_backfill_temp.db`
+- Fields populated: `ai_selected_index`, `ai_crop_coords`, `ai_confidence`
+- User fields NULL (will be filled in Phase 1B)
+
+**Command:**
 ```bash
-# Identify project
-grep "ProjectName" data/timesheet.csv
+cd /Users/eriksjaastad/projects/image-workflow
+source .venv311/bin/activate
 
-# Verify file modification dates match project window
-stat -f "%Sm" -t "%Y-%m-%d" "training data/ProjectName_final/"*.png | sort -u
+python3 scripts/ai/backfill_project_phase1a_ai_predictions.py \
+  --project-id mojo3 \
+  --original-dir /Volumes/T7Shield/Eros/original/mojo3 \
+  --output-db data/training/ai_training_decisions/mojo3_backfill_temp.db
 ```
 
-### 2) Dry Run
+**Runtime:** ~15-20 minutes for 6,000 groups (depends on GPU/CPU)
+
+**What It Does:**
+1. Groups original images using standard grouping logic
+2. Loads CLIP embeddings (from cache or computes on-the-fly)
+3. Runs ranker model to select best image
+4. Runs crop proposer to suggest crop coordinates
+5. Stores all AI predictions in temp database
+
+---
+
+### Phase 1B: Extract User Ground Truth
+
+**Purpose:** Find user's actual selections and crop coordinates from physical cropped images.
+
+**Input:**
+- Temp database from Phase 1A (with AI predictions)
+- Final cropped images directory (e.g., `mojo3/`)
+
+**Output:**
+- Updated temp database with BOTH AI predictions and user ground truth
+- Fields populated: `user_selected_index`, `user_action`, `final_crop_coords`
+- Match fields calculated: `selection_match`, `crop_match`
+
+**Command:**
 ```bash
-python3 scripts/tools/backfill_v3_from_archives.py ProjectName
+python3 scripts/ai/backfill_project_phase1b_user_data.py \
+  --temp-db data/training/ai_training_decisions/mojo3_backfill_temp.db \
+  --final-dir mojo3/ \
+  --dry-run  # Remove --dry-run to actually run
 ```
-- Inspect console and any generated inspection report.
 
-### 3) Execute
+**Runtime:** ~20 minutes for 6,000 groups (template matching is CPU intensive)
+
+**What It Does:**
+1. For each group in temp database:
+   - Searches final directory for images from that group (recursive)
+   - If found: Extracts crop coordinates via OpenCV template matching
+   - If not found: Marks as `user_action = 'reject'` (user rejected entire group)
+2. Determines user action:
+   - If `final_crop_coords ≈ [0, 0, 1, 1]` (within 2% tolerance) → `'approve'`
+   - If coordinates differ significantly → `'crop'`
+   - If image not in final directory → `'reject'`
+3. Calculates accuracy metrics:
+   - `selection_match`: Did AI pick same image as user?
+   - `crop_match`: Was AI's crop within 5% of user's crop?
+
+**Important:** For `'reject'` actions, `user_selected_index` is set to AI's selection (database schema requires 0-3, not NULL).
+
+---
+
+### Phase 2: Merge with Real Database
+
+**Purpose:** Intelligently merge temp database into production database without overwriting existing data.
+
+**Input:**
+- Temp database (complete from Phase 1A + 1B)
+- Real production database (may have partial data)
+
+**Output:**
+- Updated production database with merged data
+
+**Command:**
 ```bash
-python3 scripts/tools/backfill_v3_from_archives.py ProjectName --execute
-```
-- Writes SQLite v3 DB under `data/training/ai_training_decisions/ProjectName.db`.
+# DRY RUN FIRST! (highly recommended)
+python3 scripts/ai/backfill_project_phase2_compare.py \
+  --temp-db data/training/ai_training_decisions/mojo3_backfill_temp.db \
+  --real-db data/training/ai_training_decisions/mojo3.db \
+  --dry-run
 
-### 4) Verify Results
+# After reviewing dry run, run for real:
+python3 scripts/ai/backfill_project_phase2_compare.py \
+  --temp-db data/training/ai_training_decisions/mojo3_backfill_temp.db \
+  --real-db data/training/ai_training_decisions/mojo3.db
+```
+
+**Runtime:** < 1 minute (pure database operations, no image processing)
+
+**Merge Rules:**
+1. **Match records by image filename** (not group_id - different workflows use different ID formats)
+2. **Add new records:** Groups in temp but not in real → insert into real database
+3. **Fill NULL fields:** Real database has NULL values, temp has data → fill the NULLs
+4. **Update coordinates if they differ beyond 1% tolerance:** Temp coordinates (from physical images) override real database
+5. **NEVER overwrite:**
+   - Timestamps (`timestamp`, `crop_timestamp`)
+   - Existing AI predictions (unless NULL)
+   - Existing user data (unless NULL or coordinates differ beyond tolerance)
+
+**Safety:**
+- Automatic backup created before merge
+- Dry-run mode shows exactly what will change
+- All timestamp data preserved from real database
+
+---
+
+## Critical Rules
+
+### 1. Physical Images Are Source of Truth
+
+**For User Data:**
+- User crop coordinates extracted via template matching from physical images
+- If coordinates in database differ from physical images → physical images win
+
+**For AI Data:**
+- AI predictions generated by running models on original images
+- If real database has AI predictions → keep them (don't overwrite with backfill)
+- Only fill NULL AI fields, never replace existing predictions
+
+### 2. User Action Semantics
+
+**Three possible values:**
+- `'approve'`: User selected an image, no crop needed (coords ≈ [0, 0, 1, 1])
+- `'crop'`: User selected an image and cropped it (coords differ from full image)
+- `'reject'`: User rejected entire group (no image in final directory)
+
+**There is NO 'skip'** - this was a mistake in earlier versions. Either user accepted something or rejected everything.
+
+### 3. Coordinate Tolerance
+
+**When comparing coordinates:**
+- **2% tolerance** for determining approve vs crop (full image detection)
+- **1% tolerance** for coordinate comparison in Phase 2 (matching existing data)
+- **5% tolerance** for crop_match calculation (AI performance metric)
+
+**Why tolerances matter:**
+- Template matching isn't pixel-perfect
+- Small variations (±1-2px) don't indicate different crops
+- Real crops differ significantly (>5% change)
+
+### 4. Database Schema Constraints
+
+**user_selected_index:**
+- MUST be 0-3 (database CHECK constraint)
+- For `'reject'` actions: set to AI's selection (not NULL, not -1)
+- This is a compromise - the field is required but meaningless for rejected groups
+
+## Real Example: mojo3 Backfill (Oct 31, 2025)
+
+**Starting point:**
+- 1,762 records in real database (from recent work with AI system)
+- ~6,000 images in `mojo3/` final directory (from months of work)
+- Need: Reconstruct complete dataset with both AI predictions and user ground truth
+
+**Phase 1A results:**
+- Processed 6,468 groups from original images
+- Generated AI predictions for all groups
+- Runtime: ~15 minutes
+- Output: temp database with 6,468 records (AI data only)
+
+**Phase 1B results:**
+- Found 4,657 images in final directory
+- Extracted crop coordinates for all 4,657
+- Identified 1,811 rejected groups (not in final)
+- Breakdown:
+  - 1,539 approve (full image kept)
+  - 3,118 crop (actually cropped)
+  - 1,811 reject (not in final)
+- Runtime: ~20 minutes
+
+**Phase 2 results:**
+- Added 4,706 new records to real database
+- Updated 4,954 existing records (filled NULL fields)
+- Corrected 0 coordinates (all matched within 1% tolerance)
+- Preserved all 1,762 original timestamps
+- Runtime: < 1 minute
+- **Final database: 6,468 total records**
+
+**AI Performance Metrics:**
+- Selection accuracy: 53.6% (AI picked same image as user)
+- Crop accuracy: 4.3% (AI's crop within 5% of user's)
+- This data enables model improvement!
+
+## Troubleshooting
+
+### "No images found in original directory"
+- Check path is correct
+- Verify images exist and have valid extensions (.png, .jpg, .jpeg)
+- Original directory should be searched recursively
+
+### "Template matching confidence too low"
+- Image might have been edited after cropping
+- Different resolution/compression
+- Try lowering confidence threshold (default 0.8)
+
+### "CHECK constraint failed: user_selected_index"
+- For rejected groups, must set `user_selected_index` to 0-3
+- Phase 1B now handles this automatically (sets to AI's selection)
+
+### "NOT NULL constraint failed"
+- Database schema requires certain fields
+- Check that Phase 1A completed successfully before running Phase 1B
+- Verify temp database has all required fields
+
+## Validation
+
+After completing all phases:
+
 ```bash
-sqlite3 data/training/ai_training_decisions/ProjectName.db \
-  "SELECT final_crop_coords, COUNT(*) FROM ai_decisions WHERE user_action='crop' GROUP BY final_crop_coords;"
+# Check record counts and action breakdown
+sqlite3 data/training/ai_training_decisions/mojo3.db \
+  "SELECT user_action, COUNT(*) FROM ai_decisions GROUP BY user_action;"
+
+# Check AI performance metrics
+sqlite3 data/training/ai_training_decisions/mojo3.db \
+  "SELECT 
+    COUNT(*) as total,
+    AVG(selection_match)*100 as selection_accuracy_pct,
+    AVG(crop_match)*100 as crop_accuracy_pct
+  FROM ai_decisions 
+  WHERE user_action != 'reject';"
+
+# Verify no NULL crop coordinates for crop actions
+sqlite3 data/training/ai_training_decisions/mojo3.db \
+  "SELECT COUNT(*) FROM ai_decisions 
+  WHERE user_action = 'crop' AND final_crop_coords IS NULL;"
+  # Should return 0
+
+# Verify all approve actions have full-image coordinates
+sqlite3 data/training/ai_training_decisions/mojo3.db \
+  "SELECT COUNT(*) FROM ai_decisions 
+  WHERE user_action = 'approve' AND final_crop_coords != '[0.0, 0.0, 1.0, 1.0]';"
+  # Should return 0 or very small number (tolerance edge cases)
 ```
-- Expect diversity of `final_crop_coords` (not all `[0,0,1,1]`).
 
-## Known Issues
-- Timestamp mismatches (e.g., `Aiko_raw`) likely indicate invalid crops.
-- Skip invalid projects or redo archives before ingest.
+## Safety Checklist
 
-## Safety
-- Read-only on archives; creates NEW DB files only.
-- No in-place changes to archived zips or images.
+Before running Phase 2 (merge):
 
-## Related Documents
-- `archives/sessions/2025-10-22/HANDOFF_HISTORICAL_BACKFILL_2025-10-22.md`
-- `core/PROJECT_LIFECYCLE_SCRIPTS.md`
-- `ai/AI_TRAINING_REFERENCE.md`
+- [ ] Dry run completed and reviewed
+- [ ] Backup of real database created
+- [ ] Sample records look correct
+- [ ] Record counts make sense
+- [ ] No unexpected "Coords to CORRECT" in dry run
+- [ ] User actions are approve/crop/reject (no 'skip')
 
+## Files Created
+
+**By Phase 1A:**
+- `data/training/ai_training_decisions/{project_id}_backfill_temp.db`
+
+**By Phase 2:**
+- `data/training/ai_training_decisions/{project_id}.db` (updated)
+- `data/training/ai_training_decisions/{project_id}.db.backup-TIMESTAMP` (automatic backup)
+
+## Related Scripts
+
+- `scripts/ai/backfill_project_phase1a_ai_predictions.py` - Phase 1A
+- `scripts/ai/backfill_project_phase1b_user_data.py` - Phase 1B
+- `scripts/ai/backfill_project_phase2_compare.py` - Phase 2
+- `scripts/ai/validate_training_data.py` - Post-backfill validation
+
+## Related Documentation
+
+- `Documents/ai/AI_TRAINING_REFERENCE.md` - Database schema
+- `Documents/ai/AI_TRAINING_GUIDE.md` - Training workflow
+- `Documents/safety/CURSOR_AI_RULES.md` - File safety rules

--- a/Documents/reference/TECHNICAL_KNOWLEDGE_BASE.md
+++ b/Documents/reference/TECHNICAL_KNOWLEDGE_BASE.md
@@ -475,11 +475,17 @@ pytest scripts/tests/test_ai_training_integration.py -v       # Integration test
 
 - `data/training/ai_training_decisions/mojo3.db` - NEW system!
 
-**Can backfill old data later (optional):**
+**Backfill Process (Oct 31, 2025):**
 
-- Read old CSVs
-- Convert to SQLite format
-- Populate historical databases
+For reconstructing complete training data from historical projects, use the 3-phase backfill process:
+
+1. **Phase 1A:** Generate AI predictions by running models on original images
+2. **Phase 1B:** Extract user ground truth from physical cropped images via template matching  
+3. **Phase 2:** Intelligently merge temp database with real database (preserves timestamps, never overwrites existing data)
+
+See: `Documents/guides/BACKFILL_QUICK_START.md`
+
+Key principle: Physical images are ALWAYS the source of truth for user data. Never copy AI predictions as user ground truth.
 
 ### **Files Reference**
 

--- a/scripts/ai/backfill_mojo3_phase1a_ai_predictions.py
+++ b/scripts/ai/backfill_mojo3_phase1a_ai_predictions.py
@@ -1,0 +1,523 @@
+#!/usr/bin/env python3
+"""
+Phase 1A: Create Temp Database with AI Predictions
+
+This script:
+1. Groups original images from /Volumes/T7Shield/Eros/original/mojo3
+2. Loads trained AI models (ranker + crop proposer)
+3. Runs AI predictions on every group
+4. Stores AI predictions in temp database (user fields NULL)
+
+Output: mojo3_backfill_temp.db (with AI predictions, no user data yet)
+
+Usage:
+    python scripts/ai/backfill_mojo3_phase1a_ai_predictions.py
+"""
+
+import json
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import open_clip
+import torch
+import torch.nn as nn
+from PIL import Image
+from tqdm import tqdm
+
+# Add project root to path
+WORKSPACE = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(WORKSPACE))
+
+# Import grouping utilities
+from scripts.utils.companion_file_utils import (
+    extract_timestamp_from_filename,
+    find_consecutive_stage_groups,
+    sort_image_files_by_timestamp_and_stage,
+)
+
+# Paths
+ORIGINAL_DIR = Path("/Volumes/T7Shield/Eros/original/mojo3")
+TEMP_DB = (
+    WORKSPACE / "data" / "training" / "ai_training_decisions" / "mojo3_backfill_temp.db"
+)
+PROJECT_ID = "mojo3"
+
+# Model paths
+RANKER_MODEL_PATH = WORKSPACE / "data" / "ai_data" / "models" / "ranker_v3_w10.pt"
+CROP_MODEL_PATH = WORKSPACE / "data" / "ai_data" / "models" / "crop_proposer_v2.pt"
+EMBEDDINGS_CACHE = WORKSPACE / "data" / "ai_data" / "cache" / "processed_images.jsonl"
+EMBEDDINGS_DIR = WORKSPACE / "data" / "ai_data" / "embeddings"
+
+# Device
+device = "mps" if torch.backends.mps.is_available() else "cpu"
+
+
+# Model architectures (must match training)
+class RankingModel(nn.Module):
+    """MLP that scores images: 512 → 256 → 64 → 1"""
+
+    def __init__(self, input_dim=512):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, 256),
+            nn.ReLU(),
+            nn.Dropout(0.3),
+            nn.Linear(256, 64),
+            nn.ReLU(),
+            nn.Linear(64, 1),
+        )
+
+    def forward(self, x):
+        return self.net(x).squeeze(-1)
+
+
+class CropProposer(nn.Module):
+    """MLP that predicts crop box from image embedding + dimensions."""
+
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(514, 512),
+            nn.ReLU(),
+            nn.Dropout(0.3),
+            nn.Linear(512, 256),
+            nn.ReLU(),
+            nn.Dropout(0.2),
+            nn.Linear(256, 128),
+            nn.ReLU(),
+            nn.Linear(128, 4),
+            nn.Sigmoid(),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+def load_embeddings_cache() -> Tuple[Dict, Dict]:
+    """Load embeddings cache and create filename lookup."""
+    cache = {}
+    filename_cache = {}
+
+    if not EMBEDDINGS_CACHE.exists():
+        print(f"⚠️  Embeddings cache not found: {EMBEDDINGS_CACHE}")
+        return cache, filename_cache
+
+    print("Loading embeddings cache...")
+    with open(EMBEDDINGS_CACHE, "r") as f:
+        for line in f:
+            data = json.loads(line)
+            img_path = data["image_path"]
+            emb_file = Path(data["embedding_file"])
+
+            if emb_file.exists():
+                emb = np.load(emb_file)
+                cache[img_path] = emb
+
+                # Also cache by filename
+                filename = Path(img_path).name
+                if filename not in filename_cache:
+                    filename_cache[filename] = []
+                filename_cache[filename].append((img_path, emb))
+
+    print(f"Loaded {len(cache)} embeddings")
+    print(f"Unique filenames: {len(filename_cache)}")
+    return cache, filename_cache
+
+
+def load_ai_models():
+    """Load trained AI models."""
+    print(f"\n🤖 Loading AI models on device: {device}")
+
+    if not RANKER_MODEL_PATH.exists():
+        print(f"❌ Ranker model not found: {RANKER_MODEL_PATH}")
+        return None, None
+
+    if not CROP_MODEL_PATH.exists():
+        print(f"❌ Crop model not found: {CROP_MODEL_PATH}")
+        return None, None
+
+    # Load ranker
+    ranker = RankingModel().to(device)
+    ranker.load_state_dict(torch.load(RANKER_MODEL_PATH, map_location=device))
+    ranker.eval()
+    print(f"✅ Loaded ranker: {RANKER_MODEL_PATH.name}")
+
+    # Load crop proposer
+    cropper = CropProposer().to(device)
+    cropper.load_state_dict(torch.load(CROP_MODEL_PATH, map_location=device))
+    cropper.eval()
+    print(f"✅ Loaded crop proposer: {CROP_MODEL_PATH.name}")
+
+    return ranker, cropper
+
+
+def load_clip_model():
+    """Load CLIP model for computing embeddings on the fly."""
+    print(f"Loading OpenCLIP model on {device}...")
+    model, _, preprocess = open_clip.create_model_and_transforms(
+        "ViT-B-32", pretrained="openai"
+    )
+    model = model.to(device)
+    model.eval()
+    return model, preprocess
+
+
+def get_embedding(
+    image_path: Path,
+    cache: Dict,
+    filename_cache: Dict,
+    clip_model=None,
+    clip_preprocess=None,
+) -> Optional[np.ndarray]:
+    """Get embedding for image, from cache or compute on the fly."""
+    # Try exact path match
+    if str(image_path) in cache:
+        return cache[str(image_path)]
+
+    # Try filename match (for images in different directories)
+    filename = image_path.name
+    if filename in filename_cache:
+        # Return first match (assumes same filename = same image)
+        return filename_cache[filename][0][1]
+
+    # Compute on the fly if CLIP model available
+    if clip_model is not None and clip_preprocess is not None:
+        try:
+            image = Image.open(image_path).convert("RGB")
+            image = clip_preprocess(image).unsqueeze(0).to(device)
+
+            with torch.no_grad():
+                embedding = clip_model.encode_image(image)
+                embedding = embedding / embedding.norm(dim=-1, keepdim=True)
+
+            return embedding.cpu().numpy().squeeze()
+        except Exception as e:
+            print(f"    ⚠️  Could not compute embedding for {filename}: {e}")
+            return None
+
+    return None
+
+
+def run_ai_predictions(
+    group: List[Path],
+    ranker,
+    cropper,
+    cache: Dict,
+    filename_cache: Dict,
+    clip_model=None,
+    clip_preprocess=None,
+) -> Tuple[Optional[int], Optional[List[float]], Optional[float]]:
+    """Run AI models on a group to get selection and crop predictions."""
+    # Get embeddings for all images in group
+    embeddings = []
+    valid_indices = []
+
+    for idx, img_path in enumerate(group):
+        emb = get_embedding(
+            img_path, cache, filename_cache, clip_model, clip_preprocess
+        )
+        if emb is not None:
+            embeddings.append(emb)
+            valid_indices.append(idx)
+
+    if not embeddings:
+        return None, None, None
+
+    # Run ranker to select best image
+    with torch.no_grad():
+        emb_tensor = torch.tensor(np.array(embeddings), dtype=torch.float32).to(device)
+        scores = ranker(emb_tensor).squeeze()
+
+        if len(embeddings) == 1:
+            best_idx = 0
+            confidence = float(scores.item())
+        else:
+            best_idx = int(scores.argmax().item())
+            confidence = float(torch.softmax(scores, dim=0)[best_idx].item())
+
+        # Map back to original group index
+        ai_selected_index = valid_indices[best_idx]
+        best_embedding = embeddings[best_idx]
+
+    # Run crop proposer on selected image
+    try:
+        # Get image dimensions
+        with Image.open(group[ai_selected_index]) as img:
+            width, height = img.size
+
+        # Normalize dimensions to [0, 1]
+        norm_width = width / 10000.0
+        norm_height = height / 10000.0
+
+        # Concatenate embedding + dimensions
+        features = np.concatenate([best_embedding, [norm_width, norm_height]])
+        features_tensor = (
+            torch.tensor(features, dtype=torch.float32).unsqueeze(0).to(device)
+        )
+
+        # Predict crop
+        with torch.no_grad():
+            crop_coords = cropper(features_tensor).squeeze().cpu().numpy().tolist()
+
+        return ai_selected_index, crop_coords, confidence
+
+    except Exception as e:
+        print(f"    ⚠️  Crop prediction failed: {e}")
+        return ai_selected_index, None, confidence
+
+
+def create_temp_database(db_path: Path):
+    """Create temporary database with schema."""
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ai_decisions (
+            group_id TEXT PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            directory TEXT,
+            batch_number INTEGER,
+            images TEXT NOT NULL,
+            ai_selected_index INTEGER,
+            ai_crop_coords TEXT,
+            ai_confidence REAL,
+            user_selected_index INTEGER,
+            user_action TEXT,
+            final_crop_coords TEXT,
+            crop_timestamp TEXT,
+            image_width INTEGER NOT NULL,
+            image_height INTEGER NOT NULL,
+            selection_match BOOLEAN,
+            crop_match BOOLEAN,
+            ai_crop_accepted BOOLEAN
+        )
+    """
+    )
+
+    conn.commit()
+    conn.close()
+    print(f"✅ Created temporary database: {db_path}")
+
+
+def group_original_images(original_dir: Path) -> List[Tuple[str, List[Path]]]:
+    """Group original images using the grouping logic."""
+    print(f"\n📁 Scanning original images in: {original_dir}")
+
+    # Get all image files
+    patterns = ["**/*.png", "**/*.jpg", "**/*.jpeg"]
+    all_images = []
+    for pattern in patterns:
+        all_images.extend(original_dir.glob(pattern))
+
+    print(f"Found {len(all_images)} images")
+
+    # Sort by timestamp and stage
+    sorted_images = sort_image_files_by_timestamp_and_stage(all_images)
+
+    # Group consecutive images
+    raw_groups = find_consecutive_stage_groups(sorted_images)
+
+    # Add group IDs
+    groups_with_ids = []
+    for group_images in raw_groups:
+        # Generate group_id from first image's timestamp
+        first_img = group_images[0]
+        timestamp = extract_timestamp_from_filename(first_img.name)
+        group_id = f"{PROJECT_ID}_group_{timestamp}"
+        groups_with_ids.append((group_id, group_images))
+
+    print(f"Created {len(groups_with_ids)} groups")
+
+    return groups_with_ids
+
+
+def process_groups_with_ai(
+    groups: List[Tuple[str, List[Path]]],
+    ranker,
+    cropper,
+    cache: Dict,
+    filename_cache: Dict,
+    clip_model=None,
+    clip_preprocess=None,
+):
+    """Process all groups with AI models."""
+    records = []
+
+    stats = {
+        "total_groups": len(groups),
+        "ai_predictions_success": 0,
+        "ai_predictions_failed": 0,
+    }
+
+    print(f"\n🤖 Running AI predictions on {len(groups)} groups...")
+
+    for i, (group_id, group_images) in enumerate(tqdm(groups, desc="Processing")):
+        # Run AI predictions
+        ai_selected_index, ai_crop_coords, ai_confidence = run_ai_predictions(
+            group_images,
+            ranker,
+            cropper,
+            cache,
+            filename_cache,
+            clip_model,
+            clip_preprocess,
+        )
+
+        if ai_selected_index is not None:
+            stats["ai_predictions_success"] += 1
+        else:
+            stats["ai_predictions_failed"] += 1
+            continue
+
+        # Get image dimensions from first image
+        try:
+            with Image.open(group_images[0]) as img:
+                image_width, image_height = img.size
+        except Exception:
+            print(f"    ⚠️  Could not read image dimensions for {group_id}")
+            continue
+
+        # Create record with AI predictions, user fields NULL
+        record = {
+            "group_id": group_id,
+            "timestamp": datetime.now().isoformat() + "Z",
+            "project_id": PROJECT_ID,
+            "directory": str(group_images[0].parent),
+            "batch_number": None,
+            "images": json.dumps([img.name for img in group_images]),
+            "ai_selected_index": ai_selected_index,
+            "ai_crop_coords": json.dumps(ai_crop_coords) if ai_crop_coords else None,
+            "ai_confidence": ai_confidence,
+            "user_selected_index": None,  # Will be filled in Phase 1B
+            "user_action": None,  # Will be filled in Phase 1B
+            "final_crop_coords": None,  # Will be filled in Phase 1B
+            "crop_timestamp": None,
+            "image_width": image_width,
+            "image_height": image_height,
+            "selection_match": None,  # Will be calculated in Phase 1B
+            "crop_match": None,  # Will be calculated in Phase 1B
+            "ai_crop_accepted": None,
+        }
+
+        records.append(record)
+
+    return records, stats
+
+
+def write_records_to_database(records: List[Dict], db_path: Path):
+    """Write records to temporary database."""
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    for record in records:
+        cursor.execute(
+            """
+            INSERT INTO ai_decisions (
+                group_id, timestamp, project_id, directory, batch_number,
+                images, ai_selected_index, ai_crop_coords, ai_confidence,
+                user_selected_index, user_action, final_crop_coords, crop_timestamp,
+                image_width, image_height, selection_match, crop_match, ai_crop_accepted
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+            (
+                record["group_id"],
+                record["timestamp"],
+                record["project_id"],
+                record["directory"],
+                record["batch_number"],
+                record["images"],
+                record["ai_selected_index"],
+                record["ai_crop_coords"],
+                record["ai_confidence"],
+                record["user_selected_index"],
+                record["user_action"],
+                record["final_crop_coords"],
+                record["crop_timestamp"],
+                record["image_width"],
+                record["image_height"],
+                record["selection_match"],
+                record["crop_match"],
+                record["ai_crop_accepted"],
+            ),
+        )
+
+    conn.commit()
+    conn.close()
+
+    print(f"✅ Wrote {len(records)} records to database")
+
+
+def main():
+    print("=" * 80)
+    print("PHASE 1A: Create Temp Database with AI Predictions")
+    print("=" * 80)
+    print(f"\nOriginal images: {ORIGINAL_DIR}")
+    print(f"Output database: {TEMP_DB}")
+    print(f"Device: {device}")
+
+    # Check directories exist
+    if not ORIGINAL_DIR.exists():
+        print(f"\n❌ ERROR: Original directory not found: {ORIGINAL_DIR}")
+        return
+
+    # Load embeddings cache
+    cache, filename_cache = load_embeddings_cache()
+
+    # Load AI models
+    ranker, cropper = load_ai_models()
+    if ranker is None or cropper is None:
+        print("\n❌ ERROR: Could not load AI models")
+        return
+
+    # Load CLIP model for computing missing embeddings
+    clip_model, clip_preprocess = load_clip_model()
+
+    # Create temporary database
+    if TEMP_DB.exists():
+        print(f"\n⚠️  Temporary database already exists: {TEMP_DB}")
+        response = input("Delete and recreate? (yes/no): ")
+        if response.lower() != "yes":
+            print("Aborted.")
+            return
+        TEMP_DB.unlink()
+
+    TEMP_DB.parent.mkdir(parents=True, exist_ok=True)
+    create_temp_database(TEMP_DB)
+
+    # Group original images
+    groups = group_original_images(ORIGINAL_DIR)
+
+    # Process groups with AI
+    records, stats = process_groups_with_ai(
+        groups, ranker, cropper, cache, filename_cache, clip_model, clip_preprocess
+    )
+
+    # Write to database
+    print("\n💾 Writing to database...")
+    write_records_to_database(records, TEMP_DB)
+
+    # Print statistics
+    print(f"\n{'=' * 80}")
+    print("STATISTICS")
+    print(f"{'=' * 80}")
+    print(f"Total groups:              {stats['total_groups']:,}")
+    print(f"AI predictions success:    {stats['ai_predictions_success']:,}")
+    print(f"AI predictions failed:     {stats['ai_predictions_failed']:,}")
+    print(f"Records in database:       {len(records):,}")
+
+    print("\n✅ PHASE 1A COMPLETE!")
+    print(f"\nTemporary database created: {TEMP_DB}")
+    print(f"  - Contains AI predictions for {len(records):,} groups")
+    print("  - User fields are NULL (will be filled in Phase 1B)")
+    print("\nNext step: Run Phase 1B to backfill user ground truth")
+    print("  python scripts/ai/backfill_mojo3_phase1b_user_data.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ai/backfill_mojo3_phase1b_user_data.py
+++ b/scripts/ai/backfill_mojo3_phase1b_user_data.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""
+Phase 1B: Backfill User Ground Truth into Temp Database
+
+This script:
+1. Reads all records from mojo3_backfill_temp.db (which has AI predictions)
+2. For each group, finds which image exists in mojo3/ final directory
+3. Extracts crop coordinates via template matching
+4. Updates database with user ground truth
+5. Calculates selection_match and crop_match metrics
+
+Input: mojo3_backfill_temp.db (with AI predictions, user fields NULL)
+Output: mojo3_backfill_temp.db (complete with both AI and user data)
+
+Usage:
+    python scripts/ai/backfill_mojo3_phase1b_user_data.py
+"""
+
+import json
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+from PIL import Image
+from tqdm import tqdm
+
+# Add project root to path
+WORKSPACE = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(WORKSPACE))
+
+# Paths
+FINAL_DIR = WORKSPACE / "mojo3"
+TEMP_DB = (
+    WORKSPACE / "data" / "training" / "ai_training_decisions" / "mojo3_backfill_temp.db"
+)
+PROJECT_ID = "mojo3"
+
+
+def extract_crop_coordinates(
+    original_path: Path, cropped_path: Path, confidence_threshold: float = 0.8
+) -> Optional[Tuple[List[float], float]]:
+    """Extract crop coordinates using template matching."""
+    try:
+        original = cv2.imread(str(original_path))
+        cropped = cv2.imread(str(cropped_path))
+
+        if original is None or cropped is None:
+            return None
+
+        orig_height, orig_width = original.shape[:2]
+        crop_height, crop_width = cropped.shape[:2]
+
+        if crop_width > orig_width or crop_height > orig_height:
+            return None
+
+        original_gray = cv2.cvtColor(original, cv2.COLOR_BGR2GRAY)
+        cropped_gray = cv2.cvtColor(cropped, cv2.COLOR_BGR2GRAY)
+
+        result = cv2.matchTemplate(original_gray, cropped_gray, cv2.TM_CCOEFF_NORMED)
+        min_val, max_val, min_loc, max_loc = cv2.minMaxLoc(result)
+
+        confidence = max_val
+        if confidence < confidence_threshold:
+            return None
+
+        x1, y1 = max_loc
+        x2, y2 = x1 + crop_width, y1 + crop_height
+
+        # Normalize coordinates
+        coords = [x1 / orig_width, y1 / orig_height, x2 / orig_width, y2 / orig_height]
+
+        return coords, confidence
+
+    except Exception:
+        return None
+
+
+def coords_match(
+    coords1: List[float], coords2: List[float], tolerance: float = 0.05
+) -> bool:
+    """Check if two coordinate sets match within tolerance."""
+    if not coords1 or not coords2:
+        return False
+
+    if len(coords1) != 4 or len(coords2) != 4:
+        return False
+
+    for c1, c2 in zip(coords1, coords2):
+        if abs(c1 - c2) > tolerance:
+            return False
+
+    return True
+
+
+def find_user_selected_image(
+    group_images: List[str], group_directory: str, final_dir: Path
+) -> Optional[Tuple[int, Path]]:
+    """Find which image from the group exists in final directory."""
+    # Try each image in the group
+    for idx, filename in enumerate(group_images):
+        # Search recursively in final directory
+        matches = list(final_dir.glob(f"**/{filename}"))
+        if matches:
+            return idx, matches[0]
+
+    return None
+
+
+def get_all_records_from_db(db_path: Path) -> List[Dict]:
+    """Read all records from database."""
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """
+        SELECT group_id, images, directory, ai_selected_index, ai_crop_coords
+        FROM ai_decisions
+        ORDER BY timestamp
+    """
+    )
+
+    results = cursor.fetchall()
+    conn.close()
+
+    records = []
+    for (
+        group_id,
+        images_json,
+        directory,
+        ai_selected_index,
+        ai_crop_coords_json,
+    ) in results:
+        try:
+            images = json.loads(images_json)
+            ai_crop_coords = (
+                json.loads(ai_crop_coords_json) if ai_crop_coords_json else None
+            )
+
+            records.append(
+                {
+                    "group_id": group_id,
+                    "images": images,
+                    "directory": directory,
+                    "ai_selected_index": ai_selected_index,
+                    "ai_crop_coords": ai_crop_coords,
+                }
+            )
+        except Exception as e:
+            print(f"  ⚠️  Error parsing record {group_id}: {e}")
+            continue
+
+    return records
+
+
+def update_record_with_user_data(
+    db_path: Path,
+    group_id: str,
+    user_selected_index: int,
+    user_action: str,
+    final_crop_coords: Optional[List[float]],
+    selection_match: bool,
+    crop_match: Optional[bool],
+    dry_run: bool = False,
+):
+    """Update database record with user ground truth."""
+    if dry_run:
+        return  # Don't actually update in dry-run mode
+
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    crop_coords_json = json.dumps(final_crop_coords) if final_crop_coords else None
+    crop_timestamp = datetime.now().isoformat() + "Z" if final_crop_coords else None
+
+    cursor.execute(
+        """
+        UPDATE ai_decisions
+        SET user_selected_index = ?,
+            user_action = ?,
+            final_crop_coords = ?,
+            crop_timestamp = ?,
+            selection_match = ?,
+            crop_match = ?
+        WHERE group_id = ?
+    """,
+        (
+            user_selected_index,
+            user_action,
+            crop_coords_json,
+            crop_timestamp,
+            selection_match,
+            crop_match,
+            group_id,
+        ),
+    )
+
+    conn.commit()
+    conn.close()
+
+
+def process_records(
+    records: List[Dict], final_dir: Path, db_path: Path, dry_run: bool = False
+):
+    """Process all records and backfill user data."""
+    stats = {
+        "total_records": len(records),
+        "found_in_final": 0,
+        "not_in_final": 0,
+        "crop_coords_extracted": 0,
+        "crop_coords_failed": 0,
+        "selection_matches": 0,
+        "crop_matches": 0,
+        "errors": 0,
+    }
+
+    samples = []  # Collect sample updates for dry-run
+
+    print(f"\n🔄 Processing {len(records)} records...")
+
+    for record in tqdm(records, desc="Backfilling" if not dry_run else "Analyzing"):
+        try:
+            group_id = record["group_id"]
+            images = record["images"]
+            directory = record["directory"]
+            ai_selected_index = record["ai_selected_index"]
+            ai_crop_coords = record["ai_crop_coords"]
+
+            # Find which image exists in final directory
+            result = find_user_selected_image(images, directory, final_dir)
+
+            if not result:
+                # User rejected/skipped this entire group
+                stats["not_in_final"] += 1
+                update_record_with_user_data(
+                    db_path,
+                    group_id,
+                    user_selected_index=None,
+                    user_action="skip",
+                    final_crop_coords=None,
+                    selection_match=None,
+                    crop_match=None,
+                    dry_run=dry_run,
+                )
+                continue
+
+            user_selected_index, final_image_path = result
+            stats["found_in_final"] += 1
+
+            # Calculate selection match
+            selection_match = (
+                (ai_selected_index == user_selected_index)
+                if ai_selected_index is not None
+                else None
+            )
+            if selection_match:
+                stats["selection_matches"] += 1
+
+            # Extract crop coordinates from physical files
+            original_path = Path(directory) / images[user_selected_index]
+
+            crop_result = extract_crop_coordinates(original_path, final_image_path)
+
+            if crop_result:
+                final_crop_coords, confidence = crop_result
+                stats["crop_coords_extracted"] += 1
+
+                # Calculate crop match
+                crop_match = (
+                    coords_match(ai_crop_coords, final_crop_coords)
+                    if ai_crop_coords
+                    else None
+                )
+                if crop_match:
+                    stats["crop_matches"] += 1
+            else:
+                final_crop_coords = None
+                crop_match = None
+                stats["crop_coords_failed"] += 1
+
+            # Collect sample for dry-run
+            if dry_run and len(samples) < 10:
+                samples.append(
+                    {
+                        "group_id": group_id,
+                        "ai_selected": ai_selected_index,
+                        "user_selected": user_selected_index,
+                        "selection_match": selection_match,
+                        "crop_match": crop_match,
+                    }
+                )
+
+            # Update database
+            update_record_with_user_data(
+                db_path,
+                group_id,
+                user_selected_index=user_selected_index,
+                user_action="crop",
+                final_crop_coords=final_crop_coords,
+                selection_match=selection_match,
+                crop_match=crop_match,
+                dry_run=dry_run,
+            )
+
+        except Exception as e:
+            print(f"  ⚠️  Error processing {record.get('group_id', 'unknown')}: {e}")
+            stats["errors"] += 1
+
+    return stats, samples
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Backfill user ground truth into temp database"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without modifying database",
+    )
+    args = parser.parse_args()
+
+    print("=" * 80)
+    print("PHASE 1B: Backfill User Ground Truth")
+    print("=" * 80)
+    print(f"Mode: {'DRY RUN' if args.dry_run else 'LIVE'}")
+    print(f"Final images: {FINAL_DIR}")
+    print(f"Database: {TEMP_DB}")
+
+    # Check database exists
+    if not TEMP_DB.exists():
+        print(f"\n❌ ERROR: Temp database not found: {TEMP_DB}")
+        print("   Run Phase 1A first to create it.")
+        return
+
+    # Check final directory exists
+    if not FINAL_DIR.exists():
+        print(f"\n❌ ERROR: Final directory not found: {FINAL_DIR}")
+        return
+
+    # Read all records
+    records = get_all_records_from_db(TEMP_DB)
+    print(f"\nFound {len(records)} records to process")
+
+    # Process records
+    stats, samples = process_records(records, FINAL_DIR, TEMP_DB, dry_run=args.dry_run)
+
+    # Print statistics
+    print(f"\n{'=' * 80}")
+    print("STATISTICS")
+    print(f"{'=' * 80}")
+    print(f"Total records:             {stats['total_records']:,}")
+    print(f"Found in final:            {stats['found_in_final']:,}")
+    print(f"Not in final (skipped):    {stats['not_in_final']:,}")
+    print(f"Crop coords extracted:     {stats['crop_coords_extracted']:,}")
+    print(f"Crop coords failed:        {stats['crop_coords_failed']:,}")
+    print("")
+
+    if stats["found_in_final"] > 0:
+        sel_pct = stats["selection_matches"] / stats["found_in_final"] * 100
+        print(
+            f"Selection matches:         {stats['selection_matches']:,} / {stats['found_in_final']:,} ({sel_pct:.1f}%)"
+        )
+
+    if stats["crop_coords_extracted"] > 0:
+        crop_pct = stats["crop_matches"] / stats["crop_coords_extracted"] * 100
+        print(
+            f"Crop matches:              {stats['crop_matches']:,} / {stats['crop_coords_extracted']:,} ({crop_pct:.1f}%)"
+        )
+
+    print(f"Errors:                    {stats['errors']:,}")
+
+    if args.dry_run and samples:
+        print("\n📋 SAMPLE UPDATES (first 10):")
+        for i, sample in enumerate(samples, 1):
+            match_str = "✅ MATCH" if sample["selection_match"] else "❌ MISMATCH"
+            print(f"  {i}. {sample['group_id']}")
+            print(
+                f"     AI selected: {sample['ai_selected']}, User selected: {sample['user_selected']} - {match_str}"
+            )
+
+    if args.dry_run:
+        print("\n💡 DRY RUN - No changes made to database")
+        print("   Run without --dry-run to apply changes")
+    else:
+        print("\n✅ PHASE 1B COMPLETE!")
+        print("\nDatabase now contains:")
+        print(f"  - AI predictions for {len(records):,} groups")
+        print(f"  - User ground truth for {stats['found_in_final']:,} groups")
+        if stats["found_in_final"] > 0:
+            print(f"  - Selection accuracy: {sel_pct:.1f}%")
+        print("\nNext step: Run Phase 2 to compare with real database")
+        print("  python scripts/ai/backfill_mojo3_phase2_compare.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ai/backfill_mojo3_phase2_compare.py
+++ b/scripts/ai/backfill_mojo3_phase2_compare.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""
+Backfill Mojo3 - Phase 2: Compare and Merge Databases
+
+This script compares the temporary backfill database with the real mojo3.db
+and merges data intelligently:
+- Adds records that exist in temp but not in real database
+- Fills NULL fields in real database from temp database
+- NEVER overwrites existing data in real database
+- Preserves all existing AI predictions
+
+Usage:
+    python scripts/ai/backfill_mojo3_phase2_compare.py --dry-run
+    python scripts/ai/backfill_mojo3_phase2_compare.py  # Actually merge
+"""
+
+import argparse
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TEMP_DB_PATH = (
+    PROJECT_ROOT / "data/training/ai_training_decisions/mojo3_backfill_temp.db"
+)
+REAL_DB_PATH = PROJECT_ROOT / "data/training/ai_training_decisions/mojo3.db"
+
+
+def get_all_records(db_path: Path) -> Dict[str, Dict[str, Any]]:
+    """Load all records from database, keyed by group_id."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT * FROM ai_decisions")
+
+    records = {}
+    for row in cursor:
+        record = dict(row)
+        records[record["group_id"]] = record
+
+    conn.close()
+    return records
+
+
+def build_image_to_record_map(records: Dict[str, Dict[str, Any]]) -> Dict[str, str]:
+    """Build a map from image filename to group_id for finding matches."""
+    image_map = {}
+    for group_id, record in records.items():
+        try:
+            images = json.loads(record["images"])
+            for img_path in images:
+                # Extract just the filename (no directory)
+                filename = Path(img_path).name
+                image_map[filename] = group_id
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return image_map
+
+
+def coords_are_close(
+    coords1_json: Optional[str], coords2_json: Optional[str], tolerance: float = 0.01
+) -> bool:
+    """
+    Check if two crop coordinate sets are within tolerance (1% default).
+
+    Args:
+        coords1_json: JSON string like "[0.1, 0.2, 0.9, 0.8]"
+        coords2_json: JSON string like "[0.1, 0.2, 0.9, 0.8]"
+        tolerance: Allowed deviation (0.01 = 1%)
+
+    Returns:
+        True if coordinates are within tolerance
+    """
+    if coords1_json is None or coords2_json is None:
+        return False
+
+    try:
+        coords1 = json.loads(coords1_json)
+        coords2 = json.loads(coords2_json)
+
+        if len(coords1) != 4 or len(coords2) != 4:
+            return False
+
+        # Check each coordinate
+        for c1, c2 in zip(coords1, coords2):
+            if abs(c1 - c2) > tolerance:
+                return False
+
+        return True
+    except Exception:
+        return False
+
+
+def compare_records(
+    temp_record: Dict[str, Any], real_record: Optional[Dict[str, Any]]
+) -> Tuple[str, Dict[str, Any]]:
+    """
+    Compare temp and real records and determine merge action.
+
+    CRITICAL RULES:
+    - NEVER overwrite timestamps (timestamp, crop_timestamp)
+    - Temp database is source of truth for: final_crop_coords, user_selected_index, user_action
+    - Use 1% tolerance when comparing coordinates
+    - Only update if coordinates differ beyond tolerance
+
+    Returns:
+        (action, data) where action is:
+        - 'add': Record doesn't exist in real DB, add it
+        - 'fill_nulls': Record exists but has NULL values to fill
+        - 'update_coords': Crop coordinates differ beyond tolerance
+        - 'skip': Record exists and is complete, no changes needed
+    """
+    if real_record is None:
+        return ("add", temp_record)
+
+    # Check which fields need to be filled or updated
+    fields_to_update = {}
+
+    # CRITICAL: Check if final_crop_coords differ (with tolerance)
+    temp_coords = temp_record.get("final_crop_coords")
+    real_coords = real_record.get("final_crop_coords")
+
+    # If both have coords, check if they're different (beyond tolerance)
+    if temp_coords and real_coords:
+        if not coords_are_close(temp_coords, real_coords, tolerance=0.01):
+            # Coordinates differ beyond 1% tolerance - temp is source of truth
+            fields_to_update["final_crop_coords"] = temp_coords
+            # Recalculate crop_match with new coordinates
+            if temp_record.get("crop_match") is not None:
+                fields_to_update["crop_match"] = temp_record["crop_match"]
+
+    # If real DB has NULL coords but temp has coords, fill them
+    if real_coords is None and temp_coords is not None:
+        fields_to_update["final_crop_coords"] = temp_coords
+
+    # AI prediction fields - only fill if NULL in real DB (never overwrite existing AI data)
+    if (
+        real_record["ai_selected_index"] is None
+        and temp_record["ai_selected_index"] is not None
+    ):
+        fields_to_update["ai_selected_index"] = temp_record["ai_selected_index"]
+
+    if (
+        real_record["ai_crop_coords"] is None
+        and temp_record["ai_crop_coords"] is not None
+    ):
+        fields_to_update["ai_crop_coords"] = temp_record["ai_crop_coords"]
+
+    if (
+        real_record["ai_confidence"] is None
+        and temp_record["ai_confidence"] is not None
+    ):
+        fields_to_update["ai_confidence"] = temp_record["ai_confidence"]
+
+    # Match fields - only fill if NULL in real DB
+    if (
+        real_record["selection_match"] is None
+        and temp_record["selection_match"] is not None
+    ):
+        fields_to_update["selection_match"] = temp_record["selection_match"]
+
+    if real_record["crop_match"] is None and temp_record["crop_match"] is not None:
+        fields_to_update["crop_match"] = temp_record["crop_match"]
+
+    # User action - only fill if NULL or empty in real DB
+    if (
+        real_record["user_action"] is None or real_record["user_action"] == ""
+    ) and temp_record["user_action"]:
+        fields_to_update["user_action"] = temp_record["user_action"]
+
+    # User selected index - only fill if NULL in real DB
+    if (
+        real_record.get("user_selected_index") is None
+        and temp_record.get("user_selected_index") is not None
+    ):
+        fields_to_update["user_selected_index"] = temp_record["user_selected_index"]
+
+    if fields_to_update:
+        # Determine if this is a coordinate correction or null filling
+        if "final_crop_coords" in fields_to_update and real_coords is not None:
+            return (
+                "update_coords",
+                {
+                    "group_id": real_record["group_id"],
+                    "updates": fields_to_update,
+                    "old_coords": real_coords,
+                },
+            )
+        else:
+            return (
+                "fill_nulls",
+                {"group_id": real_record["group_id"], "updates": fields_to_update},
+            )
+
+    return ("skip", {})
+
+
+def add_record(cursor: sqlite3.Cursor, record: Dict[str, Any], dry_run: bool = True):
+    """Add a new record to the real database."""
+    if dry_run:
+        return
+
+    cursor.execute(
+        """
+        INSERT INTO ai_decisions (
+            group_id, timestamp, project_id, directory, batch_number,
+            images, ai_selected_index, ai_crop_coords, ai_confidence,
+            user_selected_index, user_action, final_crop_coords,
+            crop_timestamp, image_width, image_height,
+            selection_match, crop_match
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """,
+        (
+            record["group_id"],
+            record["timestamp"],
+            record["project_id"],
+            record["directory"],
+            record["batch_number"],
+            record["images"],
+            record["ai_selected_index"],
+            record["ai_crop_coords"],
+            record["ai_confidence"],
+            record["user_selected_index"],
+            record["user_action"],
+            record["final_crop_coords"],
+            record["crop_timestamp"],
+            record["image_width"],
+            record["image_height"],
+            record["selection_match"],
+            record["crop_match"],
+        ),
+    )
+
+
+def fill_null_fields(
+    cursor: sqlite3.Cursor, group_id: str, updates: Dict[str, Any], dry_run: bool = True
+):
+    """
+    Update NULL fields in existing record.
+
+    CRITICAL: NEVER update timestamp or crop_timestamp fields.
+    """
+    if dry_run:
+        return
+
+    # Remove any timestamp fields if they somehow got included
+    updates_safe = {
+        k: v for k, v in updates.items() if k not in ["timestamp", "crop_timestamp"]
+    }
+
+    if not updates_safe:
+        return  # Nothing to update
+
+    set_clauses = []
+    values = []
+
+    for field, value in updates_safe.items():
+        set_clauses.append(f"{field} = ?")
+        values.append(value)
+
+    values.append(group_id)  # For WHERE clause
+
+    sql = f"UPDATE ai_decisions SET {', '.join(set_clauses)} WHERE group_id = ?"
+    cursor.execute(sql, values)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Phase 2: Compare and merge backfill data"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without modifying database",
+    )
+    args = parser.parse_args()
+
+    print("=" * 80)
+    print("PHASE 2: DATABASE COMPARISON & MERGE")
+    print("=" * 80)
+    print(f"Temp DB: {TEMP_DB_PATH}")
+    print(f"Real DB: {REAL_DB_PATH}")
+    print(
+        f"Mode: {'DRY RUN (no changes)' if args.dry_run else 'LIVE (will modify database)'}"
+    )
+    print()
+
+    # Verify files exist
+    if not TEMP_DB_PATH.exists():
+        print(f"❌ ERROR: Temp database not found: {TEMP_DB_PATH}")
+        return
+
+    if not REAL_DB_PATH.exists():
+        print(f"❌ ERROR: Real database not found: {REAL_DB_PATH}")
+        return
+
+    print("Loading databases...")
+    temp_records = get_all_records(TEMP_DB_PATH)
+    real_records = get_all_records(REAL_DB_PATH)
+
+    print(f"  Temp DB: {len(temp_records):,} records")
+    print(f"  Real DB: {len(real_records):,} records")
+    print()
+
+    # Build image filename to group_id maps for matching
+    print("Building image filename maps...")
+    temp_image_map = build_image_to_record_map(temp_records)
+    real_image_map = build_image_to_record_map(real_records)
+
+    print(f"  Temp DB: {len(temp_image_map):,} unique images")
+    print(f"  Real DB: {len(real_image_map):,} unique images")
+    print()
+
+    # Find overlapping images (same filename in both databases)
+    overlapping_images = set(temp_image_map.keys()) & set(real_image_map.keys())
+    print(f"  Overlapping images: {len(overlapping_images):,}")
+    print()
+
+    # Compare all records
+    print("Comparing records...")
+    actions = {"add": [], "fill_nulls": [], "update_coords": [], "skip": []}
+
+    # Track which temp records matched with real records
+    matched_temp_group_ids = set()
+
+    # First, check for overlapping images and compare their records
+    for img_filename in overlapping_images:
+        temp_group_id = temp_image_map[img_filename]
+        real_group_id = real_image_map[img_filename]
+
+        temp_record = temp_records[temp_group_id]
+        real_record = real_records[real_group_id]
+
+        action, data = compare_records(temp_record, real_record)
+        actions[action].append((real_group_id, data))  # Use real group_id for updates
+        matched_temp_group_ids.add(temp_group_id)
+
+    # Then, add any temp records that didn't match (new groups to add)
+    for temp_group_id, temp_record in temp_records.items():
+        if temp_group_id not in matched_temp_group_ids:
+            actions["add"].append((temp_group_id, temp_record))
+
+    # Display summary
+    print()
+    print("=" * 80)
+    print("COMPARISON RESULTS")
+    print("=" * 80)
+    print(f"Records to ADD:       {len(actions['add']):,}")
+    print(f"Records to UPDATE:    {len(actions['fill_nulls']):,}")
+    print(
+        f"Coords to CORRECT:    {len(actions['update_coords']):,} ⚠️  (temp is source of truth)"
+    )
+    print(f"Records to SKIP:      {len(actions['skip']):,}")
+    print()
+
+    # Show sample actions
+    if actions["add"]:
+        print("Sample records to ADD (first 5):")
+        for i, (group_id, record) in enumerate(actions["add"][:5]):
+            print(f"  {i+1}. {group_id}")
+            print(
+                f"     - AI: index={record['ai_selected_index']}, confidence={record['ai_confidence']:.2f}"
+            )
+            print(
+                f"     - User: action={record['user_action']}, coords={record['final_crop_coords'][:50] if record['final_crop_coords'] else None}"
+            )
+        if len(actions["add"]) > 5:
+            print(f"  ... and {len(actions['add']) - 5:,} more")
+        print()
+
+    if actions["update_coords"]:
+        print("⚠️  Sample COORDINATE CORRECTIONS (first 5):")
+        print(
+            "    (Temp coordinates extracted from physical images are source of truth)"
+        )
+        for i, (group_id, data) in enumerate(actions["update_coords"][:5]):
+            print(f"  {i+1}. {group_id}")
+            print(f"     - OLD: {data['old_coords'][:60]}...")
+            new_coords = data["updates"]["final_crop_coords"]
+            print(f"     - NEW: {new_coords[:60]}...")
+        if len(actions["update_coords"]) > 5:
+            print(f"  ... and {len(actions['update_coords']) - 5:,} more")
+        print()
+
+    if actions["fill_nulls"]:
+        print("Sample records to UPDATE (first 5):")
+        for i, (group_id, data) in enumerate(actions["fill_nulls"][:5]):
+            print(f"  {i+1}. {group_id}")
+            for field, value in data["updates"].items():
+                if isinstance(value, str) and len(value) > 50:
+                    value = value[:50] + "..."
+                print(f"     - Fill {field}: {value}")
+        if len(actions["fill_nulls"]) > 5:
+            print(f"  ... and {len(actions['fill_nulls']) - 5:,} more")
+        print()
+
+    # Check for records in real DB but not in temp (shouldn't happen, just informational)
+    real_only = set(real_records.keys()) - set(temp_records.keys())
+    if real_only:
+        print(f"Records in real DB but NOT in temp: {len(real_only):,}")
+        print("  (These will be left unchanged - this is expected)")
+        print()
+
+    # Execute changes
+    if args.dry_run:
+        print("=" * 80)
+        print("🔍 DRY RUN COMPLETE - No changes made")
+        print("=" * 80)
+        print()
+        print("To actually merge the data, run without --dry-run:")
+        print("  python scripts/ai/backfill_mojo3_phase2_compare.py")
+        print()
+        print("⚠️  RECOMMENDATION: Review the samples above before proceeding!")
+    else:
+        print("=" * 80)
+        print("⚠️  APPLYING CHANGES TO REAL DATABASE")
+        print("=" * 80)
+
+        conn = sqlite3.connect(str(REAL_DB_PATH))
+        cursor = conn.cursor()
+
+        try:
+            # Add new records
+            print(f"Adding {len(actions['add']):,} new records...")
+            for group_id, record in actions["add"]:
+                add_record(cursor, record, dry_run=False)
+
+            # Update existing records (fill NULLs)
+            print(
+                f"Updating {len(actions['fill_nulls']):,} existing records (filling NULLs)..."
+            )
+            for group_id, data in actions["fill_nulls"]:
+                fill_null_fields(
+                    cursor, data["group_id"], data["updates"], dry_run=False
+                )
+
+            # Correct coordinates
+            print(
+                f"Correcting {len(actions['update_coords']):,} crop coordinates (temp is source of truth)..."
+            )
+            for group_id, data in actions["update_coords"]:
+                fill_null_fields(
+                    cursor, data["group_id"], data["updates"], dry_run=False
+                )
+
+            conn.commit()
+            print()
+            print("✅ MERGE COMPLETE!")
+            print()
+            print("Summary:")
+            print(f"  - Added: {len(actions['add']):,} records")
+            print(f"  - Updated: {len(actions['fill_nulls']):,} records (filled NULLs)")
+            print(
+                f"  - Corrected: {len(actions['update_coords']):,} records (fixed coordinates)"
+            )
+            print(f"  - Skipped: {len(actions['skip']):,} records (already complete)")
+            print(
+                f"  - Total in real DB: {len(real_records) + len(actions['add']):,} records"
+            )
+
+        except Exception as e:
+            print(f"❌ ERROR during merge: {e}")
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+        print()
+        print("=" * 80)
+        print("🎉 BACKFILL COMPLETE!")
+        print("=" * 80)
+        print()
+        print("Next steps:")
+        print("  1. Validate the merged data:")
+        print("     python scripts/ai/validate_training_data.py mojo3")
+        print("  2. Check AI performance stats:")
+        print("     sqlite3 data/training/ai_training_decisions/mojo3.db")
+        print(
+            "     SELECT COUNT(*), AVG(selection_match), AVG(crop_match) FROM ai_decisions;"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ai/backfill_mojo3_with_ai_phase1.py
+++ b/scripts/ai/backfill_mojo3_with_ai_phase1.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""
+Phase 1: Backfill mojo3 Database with AI Predictions
+
+This script:
+1. Groups original images from mojo3
+2. Runs trained AI models to get predictions (selection + crop)
+3. Matches against final directory to find user choices
+4. Extracts crop coordinates via template matching
+5. Creates temporary database with BOTH AI predictions and user ground truth
+
+Output: mojo3_backfill_temp.db
+
+Usage:
+    python scripts/ai/backfill_mojo3_with_ai_phase1.py
+"""
+
+import json
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+from PIL import Image
+
+# Add project root to path
+WORKSPACE = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(WORKSPACE))
+
+# Import grouping utilities
+from scripts.utils.companion_file_utils import (
+    extract_timestamp_from_filename,
+    find_consecutive_stage_groups,
+    sort_image_files_by_timestamp_and_stage,
+)
+
+# Paths
+ORIGINAL_DIR = Path("/Volumes/T7Shield/Eros/original/mojo3")
+FINAL_DIR = WORKSPACE / "mojo3"
+TEMP_DB = (
+    WORKSPACE / "data" / "training" / "ai_training_decisions" / "mojo3_backfill_temp.db"
+)
+PROJECT_ID = "mojo3"
+
+# AI Model paths (will check if they exist)
+RANKER_MODEL_PATH = WORKSPACE / "data" / "ai_data" / "models" / "ranker_v2.pth"
+CROP_MODEL_PATH = WORKSPACE / "data" / "ai_data" / "models" / "crop_proposer.pth"
+
+
+def load_ai_models():
+    """Load trained AI models if available."""
+    try:
+        import torch
+
+        # Check if models exist
+        if not RANKER_MODEL_PATH.exists() or not CROP_MODEL_PATH.exists():
+            print(
+                "⚠️  AI models not found. Will create database without AI predictions."
+            )
+            return None, None
+
+        print("🤖 Loading AI models...")
+        # TODO: Load actual models - this needs the model architecture classes
+        # For now, return None to indicate models aren't loaded
+        # You'll need to implement actual model loading based on your training code
+
+        print("⚠️  AI model loading not yet implemented.")
+        print("    Database will be created with NULL AI predictions.")
+        return None, None
+
+    except ImportError:
+        print("⚠️  PyTorch not available. Creating database without AI predictions.")
+        return None, None
+
+
+def extract_crop_coordinates(
+    original_path: Path, cropped_path: Path, confidence_threshold: float = 0.8
+) -> Optional[Tuple[List[float], float]]:
+    """Extract crop coordinates using template matching."""
+    try:
+        original = cv2.imread(str(original_path))
+        cropped = cv2.imread(str(cropped_path))
+
+        if original is None or cropped is None:
+            return None
+
+        orig_height, orig_width = original.shape[:2]
+        crop_height, crop_width = cropped.shape[:2]
+
+        if crop_width > orig_width or crop_height > orig_height:
+            return None
+
+        original_gray = cv2.cvtColor(original, cv2.COLOR_BGR2GRAY)
+        cropped_gray = cv2.cvtColor(cropped, cv2.COLOR_BGR2GRAY)
+
+        result = cv2.matchTemplate(original_gray, cropped_gray, cv2.TM_CCOEFF_NORMED)
+        min_val, max_val, min_loc, max_loc = cv2.minMaxLoc(result)
+
+        confidence = max_val
+        if confidence < confidence_threshold:
+            return None
+
+        x1, y1 = max_loc
+        x2, y2 = x1 + crop_width, y1 + crop_height
+
+        # Normalize coordinates
+        coords = [x1 / orig_width, y1 / orig_height, x2 / orig_width, y2 / orig_height]
+
+        return coords, confidence
+
+    except Exception:
+        return None
+
+
+def create_temp_database(db_path: Path):
+    """Create temporary database with schema."""
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ai_decisions (
+            group_id TEXT PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            directory TEXT,
+            batch_number INTEGER,
+            images TEXT NOT NULL,
+            ai_selected_index INTEGER,
+            ai_crop_coords TEXT,
+            ai_confidence REAL,
+            user_selected_index INTEGER NOT NULL,
+            user_action TEXT NOT NULL,
+            final_crop_coords TEXT,
+            crop_timestamp TEXT,
+            image_width INTEGER NOT NULL,
+            image_height INTEGER NOT NULL,
+            selection_match BOOLEAN,
+            crop_match BOOLEAN,
+            ai_crop_accepted BOOLEAN
+        )
+    """
+    )
+
+    conn.commit()
+    conn.close()
+    print(f"✅ Created temporary database: {db_path}")
+
+
+def group_original_images(original_dir: Path) -> List[Tuple[str, List[Path]]]:
+    """Group original images using the grouping logic."""
+    print(f"\n📁 Scanning original images in: {original_dir}")
+
+    # Get all image files
+    patterns = ["**/*.png", "**/*.jpg", "**/*.jpeg"]
+    all_images = []
+    for pattern in patterns:
+        all_images.extend(original_dir.glob(pattern))
+
+    print(f"Found {len(all_images)} images")
+
+    # Sort by timestamp and stage
+    sorted_images = sort_image_files_by_timestamp_and_stage(all_images)
+
+    # Group consecutive images
+    groups = find_consecutive_stage_groups(sorted_images)
+
+    print(f"Created {len(groups)} groups")
+
+    return groups
+
+
+def find_selected_image(
+    group: List[Path], final_dir: Path
+) -> Optional[Tuple[int, Path]]:
+    """Find which image from the group exists in final directory."""
+    for idx, img_path in enumerate(group):
+        filename = img_path.name
+
+        # Search recursively in final directory
+        matches = list(final_dir.glob(f"**/{filename}"))
+        if matches:
+            return idx, matches[0]
+
+    return None
+
+
+def process_groups(
+    groups: List[Tuple[str, List[Path]]], final_dir: Path, ranker=None, cropper=None
+):
+    """Process all groups and create database records."""
+    records = []
+
+    stats = {
+        "total_groups": len(groups),
+        "found_in_final": 0,
+        "not_in_final": 0,
+        "coord_extracted": 0,
+        "coord_failed": 0,
+    }
+
+    for i, (group_id, group_images) in enumerate(groups, 1):
+        if i % 100 == 0:
+            print(f"  Processing group {i}/{len(groups)} ({i/len(groups)*100:.1f}%)")
+
+        # Find which image was selected
+        selection_result = find_selected_image(group_images, final_dir)
+
+        if not selection_result:
+            stats["not_in_final"] += 1
+            continue
+
+        user_selected_index, final_image_path = selection_result
+        stats["found_in_final"] += 1
+
+        # Get image dimensions from selected image
+        try:
+            with Image.open(group_images[user_selected_index]) as img:
+                image_width, image_height = img.size
+        except Exception:
+            print(f"    ⚠️  Could not read image dimensions for {group_id}")
+            continue
+
+        # Extract crop coordinates
+        crop_result = extract_crop_coordinates(
+            group_images[user_selected_index], final_image_path
+        )
+
+        if crop_result:
+            final_crop_coords, confidence = crop_result
+            stats["coord_extracted"] += 1
+        else:
+            final_crop_coords = None
+            stats["coord_failed"] += 1
+
+        # TODO: Run AI models here to get predictions
+        # For now, AI fields are NULL
+        ai_selected_index = None
+        ai_crop_coords = None
+        ai_confidence = None
+        selection_match = None
+        crop_match = None
+        ai_crop_accepted = None
+
+        # Create record
+        record = {
+            "group_id": group_id,
+            "timestamp": datetime.now().isoformat() + "Z",
+            "project_id": PROJECT_ID,
+            "directory": str(group_images[0].parent),
+            "batch_number": None,
+            "images": json.dumps([img.name for img in group_images]),
+            "ai_selected_index": ai_selected_index,
+            "ai_crop_coords": json.dumps(ai_crop_coords) if ai_crop_coords else None,
+            "ai_confidence": ai_confidence,
+            "user_selected_index": user_selected_index,
+            "user_action": "crop",
+            "final_crop_coords": (
+                json.dumps(final_crop_coords) if final_crop_coords else None
+            ),
+            "crop_timestamp": (
+                datetime.now().isoformat() + "Z" if final_crop_coords else None
+            ),
+            "image_width": image_width,
+            "image_height": image_height,
+            "selection_match": selection_match,
+            "crop_match": crop_match,
+            "ai_crop_accepted": ai_crop_accepted,
+        }
+
+        records.append(record)
+
+    return records, stats
+
+
+def write_records_to_database(records: List[Dict], db_path: Path):
+    """Write records to temporary database."""
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    for record in records:
+        cursor.execute(
+            """
+            INSERT INTO ai_decisions (
+                group_id, timestamp, project_id, directory, batch_number,
+                images, ai_selected_index, ai_crop_coords, ai_confidence,
+                user_selected_index, user_action, final_crop_coords, crop_timestamp,
+                image_width, image_height, selection_match, crop_match, ai_crop_accepted
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+            (
+                record["group_id"],
+                record["timestamp"],
+                record["project_id"],
+                record["directory"],
+                record["batch_number"],
+                record["images"],
+                record["ai_selected_index"],
+                record["ai_crop_coords"],
+                record["ai_confidence"],
+                record["user_selected_index"],
+                record["user_action"],
+                record["final_crop_coords"],
+                record["crop_timestamp"],
+                record["image_width"],
+                record["image_height"],
+                record["selection_match"],
+                record["crop_match"],
+                record["ai_crop_accepted"],
+            ),
+        )
+
+    conn.commit()
+    conn.close()
+
+    print(f"✅ Wrote {len(records)} records to database")
+
+
+def main():
+    print("=" * 80)
+    print("PHASE 1: Backfill mojo3 Database with AI Predictions")
+    print("=" * 80)
+    print(f"\nOriginal images: {ORIGINAL_DIR}")
+    print(f"Final images:    {FINAL_DIR}")
+    print(f"Output database: {TEMP_DB}")
+
+    # Check directories exist
+    if not ORIGINAL_DIR.exists():
+        print(f"\n❌ ERROR: Original directory not found: {ORIGINAL_DIR}")
+        return
+
+    if not FINAL_DIR.exists():
+        print(f"\n❌ ERROR: Final directory not found: {FINAL_DIR}")
+        return
+
+    # Load AI models
+    ranker, cropper = load_ai_models()
+
+    # Create temporary database
+    if TEMP_DB.exists():
+        print(f"\n⚠️  Temporary database already exists: {TEMP_DB}")
+        response = input("Delete and recreate? (yes/no): ")
+        if response.lower() != "yes":
+            print("Aborted.")
+            return
+        TEMP_DB.unlink()
+
+    TEMP_DB.parent.mkdir(parents=True, exist_ok=True)
+    create_temp_database(TEMP_DB)
+
+    # Group original images
+    groups = group_original_images(ORIGINAL_DIR)
+
+    # Process groups
+    print(f"\n🔄 Processing {len(groups)} groups...")
+    records, stats = process_groups(groups, FINAL_DIR, ranker, cropper)
+
+    # Write to database
+    print("\n💾 Writing to database...")
+    write_records_to_database(records, TEMP_DB)
+
+    # Print statistics
+    print(f"\n{'=' * 80}")
+    print("STATISTICS")
+    print(f"{'=' * 80}")
+    print(f"Total groups:              {stats['total_groups']:,}")
+    print(f"Found in final:            {stats['found_in_final']:,}")
+    print(f"Not in final (deleted):    {stats['not_in_final']:,}")
+    print(f"Crop coords extracted:     {stats['coord_extracted']:,}")
+    print(f"Crop coords failed:        {stats['coord_failed']:,}")
+    print(f"\nRecords in database:       {len(records):,}")
+
+    print("\n✅ PHASE 1 COMPLETE!")
+    print(f"\nTemporary database created: {TEMP_DB}")
+    print("\nNext step: Run Phase 2 to compare with existing database")
+    print("  python scripts/ai/backfill_mojo3_with_ai_phase2.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ai/backfill_project_phase1a_ai_predictions.py
+++ b/scripts/ai/backfill_project_phase1a_ai_predictions.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""
+Phase 1A: Create Temp Database with AI Predictions
+
+This script:
+1. Groups original images from specified directory
+2. Loads trained AI models (ranker + crop proposer)
+3. Runs AI predictions on every group
+4. Stores AI predictions in temp database (user fields NULL)
+
+Output: {project_id}_backfill_temp.db (with AI predictions, no user data yet)
+
+Usage:
+    python scripts/ai/backfill_project_phase1a_ai_predictions.py \\
+        --project-id mojo3 \\
+        --original-dir /Volumes/T7Shield/Eros/original/mojo3 \\
+        --output-db data/training/ai_training_decisions/mojo3_backfill_temp.db
+"""
+
+import argparse
+import json
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import open_clip
+import torch
+import torch.nn as nn
+from PIL import Image
+from tqdm import tqdm
+
+# Add project root to path
+WORKSPACE = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(WORKSPACE))
+
+# Import grouping utilities
+from scripts.utils.companion_file_utils import (
+    extract_timestamp_from_filename,
+    find_consecutive_stage_groups,
+    sort_image_files_by_timestamp_and_stage,
+)
+
+# Model paths (these are standard)
+RANKER_MODEL_PATH = WORKSPACE / "data" / "ai_data" / "models" / "ranker_v3_w10.pt"
+CROP_MODEL_PATH = WORKSPACE / "data" / "ai_data" / "models" / "crop_proposer_v2.pt"
+EMBEDDINGS_CACHE = WORKSPACE / "data" / "ai_data" / "cache" / "processed_images.jsonl"
+EMBEDDINGS_DIR = WORKSPACE / "data" / "ai_data" / "embeddings"
+
+# Device
+device = "mps" if torch.backends.mps.is_available() else "cpu"
+
+
+# Model architectures (must match training)
+class RankingModel(nn.Module):
+    """MLP that scores images: 512 → 256 → 64 → 1"""
+
+    def __init__(self, input_dim=512):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, 256),
+            nn.ReLU(),
+            nn.Dropout(0.3),
+            nn.Linear(256, 64),
+            nn.ReLU(),
+            nn.Linear(64, 1),
+        )
+
+    def forward(self, x):
+        return self.net(x).squeeze(-1)
+
+
+class CropProposer(nn.Module):
+    """MLP that predicts crop coords: (512 + 2 dims) → 256 → 128 → 4"""
+
+    def __init__(self, input_dim=514):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, 256),
+            nn.ReLU(),
+            nn.Dropout(0.3),
+            nn.Linear(256, 128),
+            nn.ReLU(),
+            nn.Linear(128, 4),
+            nn.Sigmoid(),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+def load_embedding_cache() -> Dict[str, np.ndarray]:
+    """Load pre-computed CLIP embeddings from cache."""
+    embeddings = {}
+    if EMBEDDINGS_CACHE.exists():
+        with open(EMBEDDINGS_CACHE, "r") as f:
+            for line in f:
+                entry = json.loads(line)
+                filename = Path(entry["filename"]).name
+                embeddings[filename] = np.array(entry["embedding"])
+    return embeddings
+
+
+def compute_clip_embedding(image_path: Path, clip_model, preprocess) -> np.ndarray:
+    """Compute CLIP embedding for an image on-the-fly."""
+    try:
+        image = Image.open(image_path).convert("RGB")
+        image_tensor = preprocess(image).unsqueeze(0).to(device)
+        with torch.no_grad():
+            embedding = clip_model.encode_image(image_tensor)
+            embedding = embedding / embedding.norm(dim=-1, keepdim=True)
+        return embedding.cpu().numpy().flatten()
+    except Exception as e:
+        print(f"    ⚠️  Failed to compute embedding for {image_path.name}: {e}")
+        return None
+
+
+def group_original_images(original_dir: Path) -> List[Tuple[str, List[Path]]]:
+    """
+    Group original images using the standard grouping logic.
+
+    Returns:
+        List of (group_id, [image_paths]) tuples
+    """
+    # Find all images recursively
+    image_extensions = {".png", ".jpg", ".jpeg"}
+    all_images = []
+    for ext in image_extensions:
+        all_images.extend(original_dir.rglob(f"*{ext}"))
+
+    if not all_images:
+        print(f"❌ No images found in {original_dir}")
+        return []
+
+    print(f"Found {len(all_images)} images")
+
+    # Sort by timestamp and stage
+    sorted_images = sort_image_files_by_timestamp_and_stage(all_images)
+
+    # Group into consecutive stage groups
+    raw_groups = find_consecutive_stage_groups(sorted_images)
+
+    # Generate group_ids from timestamps
+    groups_with_ids = []
+    for group_images in raw_groups:
+        first_img = group_images[0]
+        timestamp = extract_timestamp_from_filename(first_img.name)
+        if not timestamp:
+            print(f"  ⚠️  Skipping group starting with {first_img.name} (no timestamp)")
+            continue
+
+        group_id = f"{first_img.parent.name}_group_{timestamp}"
+        groups_with_ids.append((group_id, group_images))
+
+    return groups_with_ids
+
+
+def run_ai_predictions(
+    group: List[Path],
+    ranker: nn.Module,
+    cropper: nn.Module,
+    embedding_cache: Dict[str, np.ndarray],
+    clip_model,
+    preprocess,
+) -> Tuple[int, Optional[List[float]], float]:
+    """
+    Run AI models on a group of images.
+
+    Returns:
+        (ai_selected_index, ai_crop_coords, ai_confidence)
+    """
+    # Get or compute embeddings
+    embeddings = []
+    valid_indices = []
+
+    for i, img_path in enumerate(group):
+        filename = img_path.name
+
+        # Try cache first
+        if filename in embedding_cache:
+            emb = embedding_cache[filename]
+        else:
+            # Compute on-the-fly
+            emb = compute_clip_embedding(img_path, clip_model, preprocess)
+            if emb is None:
+                continue
+
+        embeddings.append(emb)
+        valid_indices.append(i)
+
+    if not embeddings:
+        print("    ⚠️  No valid embeddings for group")
+        return (0, None, 0.0)
+
+    # Run ranker
+    embeddings_tensor = torch.tensor(np.array(embeddings), dtype=torch.float32).to(
+        device
+    )
+
+    with torch.no_grad():
+        scores = ranker(embeddings_tensor)
+
+        # Handle single image case
+        if len(scores.shape) == 0:
+            best_idx = 0
+            confidence = 1.0
+        else:
+            best_idx = int(scores.argmax().item())
+            confidence = float(torch.softmax(scores, dim=0)[best_idx].item())
+
+        # Map back to original group index
+        ai_selected_index = valid_indices[best_idx]
+        best_embedding = embeddings[best_idx]
+
+    # Run crop proposer on selected image
+    try:
+        # Get image dimensions
+        with Image.open(group[ai_selected_index]) as img:
+            width, height = img.size
+
+        # Normalize dimensions to [0, 1]
+        norm_width = width / 10000.0
+        norm_height = height / 10000.0
+
+        # Concatenate embedding + dimensions
+        features = np.concatenate([best_embedding, [norm_width, norm_height]])
+        features_tensor = (
+            torch.tensor(features, dtype=torch.float32).unsqueeze(0).to(device)
+        )
+
+        # Predict crop
+        with torch.no_grad():
+            crop_coords = cropper(features_tensor).squeeze().cpu().numpy().tolist()
+
+        return ai_selected_index, crop_coords, confidence
+
+    except Exception as e:
+        print(f"    ⚠️  Crop prediction failed: {e}")
+        return ai_selected_index, None, confidence
+
+
+def create_temp_database(db_path: Path, project_id: str):
+    """Create temporary database with schema."""
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ai_decisions (
+            group_id TEXT PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            directory TEXT,
+            batch_number INTEGER,
+            images TEXT NOT NULL,
+            ai_selected_index INTEGER,
+            ai_crop_coords TEXT,
+            ai_confidence REAL,
+            user_selected_index INTEGER,
+            user_action TEXT,
+            final_crop_coords TEXT,
+            crop_timestamp TEXT,
+            image_width INTEGER NOT NULL,
+            image_height INTEGER NOT NULL,
+            selection_match BOOLEAN,
+            crop_match BOOLEAN
+        )
+    """
+    )
+
+    conn.commit()
+    conn.close()
+    print(f"✅ Created temp database: {db_path}")
+
+
+def insert_ai_prediction(
+    db_path: Path,
+    group_id: str,
+    project_id: str,
+    directory: str,
+    images: List[Path],
+    ai_selected_index: int,
+    ai_crop_coords: Optional[List[float]],
+    ai_confidence: float,
+):
+    """Insert AI prediction into temp database."""
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    # Get image dimensions from selected image
+    with Image.open(images[ai_selected_index]) as img:
+        width, height = img.size
+
+    # Convert images to relative filenames
+    image_filenames = [img.name for img in images]
+
+    cursor.execute(
+        """
+        INSERT INTO ai_decisions (
+            group_id, timestamp, project_id, directory, batch_number,
+            images, ai_selected_index, ai_crop_coords, ai_confidence,
+            user_selected_index, user_action, final_crop_coords,
+            crop_timestamp, image_width, image_height,
+            selection_match, crop_match
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """,
+        (
+            group_id,
+            datetime.utcnow().isoformat() + "Z",
+            project_id,
+            str(directory),
+            None,  # batch_number
+            json.dumps(image_filenames),
+            ai_selected_index,
+            json.dumps(ai_crop_coords) if ai_crop_coords else None,
+            ai_confidence,
+            None,  # user_selected_index (filled in Phase 1B)
+            None,  # user_action (filled in Phase 1B)
+            None,  # final_crop_coords (filled in Phase 1B)
+            None,  # crop_timestamp
+            width,
+            height,
+            None,  # selection_match (filled in Phase 1B)
+            None,  # crop_match (filled in Phase 1B)
+        ),
+    )
+
+    conn.commit()
+    conn.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Phase 1A: Generate AI predictions for backfill"
+    )
+    parser.add_argument("--project-id", required=True, help="Project ID (e.g., mojo3)")
+    parser.add_argument(
+        "--original-dir", required=True, help="Directory containing original images"
+    )
+    parser.add_argument(
+        "--output-db", required=True, help="Path to output temp database"
+    )
+    args = parser.parse_args()
+
+    original_dir = Path(args.original_dir)
+    output_db = Path(args.output_db)
+    project_id = args.project_id
+
+    print("=" * 80)
+    print("PHASE 1A: AI PREDICTIONS")
+    print("=" * 80)
+    print(f"Project ID: {project_id}")
+    print(f"Original images: {original_dir}")
+    print(f"Output database: {output_db}")
+    print()
+
+    # Verify paths
+    if not original_dir.exists():
+        print(f"❌ ERROR: Original directory not found: {original_dir}")
+        return
+
+    if not RANKER_MODEL_PATH.exists():
+        print(f"❌ ERROR: Ranker model not found: {RANKER_MODEL_PATH}")
+        return
+
+    if not CROP_MODEL_PATH.exists():
+        print(f"❌ ERROR: Crop proposer model not found: {CROP_MODEL_PATH}")
+        return
+
+    # Load models
+    print("Loading AI models...")
+    ranker = RankingModel().to(device)
+    ranker.load_state_dict(torch.load(RANKER_MODEL_PATH, map_location=device))
+    ranker.eval()
+    print(f"  ✅ Loaded ranker: {RANKER_MODEL_PATH.name}")
+
+    cropper = CropProposer().to(device)
+    cropper.load_state_dict(torch.load(CROP_MODEL_PATH, map_location=device))
+    cropper.eval()
+    print(f"  ✅ Loaded crop proposer: {CROP_MODEL_PATH.name}")
+
+    # Load CLIP model for on-the-fly embeddings
+    print("Loading CLIP model...")
+    clip_model, _, preprocess = open_clip.create_model_and_transforms(
+        "ViT-B-32", pretrained="openai"
+    )
+    clip_model = clip_model.to(device)
+    clip_model.eval()
+    print("  ✅ Loaded CLIP model")
+
+    # Load embedding cache
+    print("Loading embedding cache...")
+    embedding_cache = load_embedding_cache()
+    print(f"  ✅ Loaded {len(embedding_cache):,} cached embeddings")
+    print()
+
+    # Group original images
+    print(f"Grouping images from {original_dir}...")
+    groups = group_original_images(original_dir)
+
+    if not groups:
+        print("❌ No groups found. Exiting.")
+        return
+
+    print(f"  ✅ Found {len(groups):,} groups")
+    print()
+
+    # Create temp database
+    if output_db.exists():
+        print(f"⚠️  Output database already exists: {output_db}")
+        response = input("Overwrite? (y/n): ")
+        if response.lower() != "y":
+            print("Aborted.")
+            return
+        output_db.unlink()
+
+    output_db.parent.mkdir(parents=True, exist_ok=True)
+    create_temp_database(output_db, project_id)
+    print()
+
+    # Process all groups
+    print(f"🔄 Running AI predictions on {len(groups):,} groups...")
+
+    for group_id, group_images in tqdm(groups, desc="Processing"):
+        ai_selected_index, ai_crop_coords, ai_confidence = run_ai_predictions(
+            group_images, ranker, cropper, embedding_cache, clip_model, preprocess
+        )
+
+        insert_ai_prediction(
+            output_db,
+            group_id,
+            project_id,
+            str(group_images[0].parent),
+            group_images,
+            ai_selected_index,
+            ai_crop_coords,
+            ai_confidence,
+        )
+
+    print()
+    print("=" * 80)
+    print("✅ PHASE 1A COMPLETE!")
+    print("=" * 80)
+    print(f"Database: {output_db}")
+    print(f"Records: {len(groups):,} groups with AI predictions")
+    print()
+    print("Next step: Run Phase 1B to add user ground truth")
+    print("  python scripts/ai/backfill_project_phase1b_user_data.py \\")
+    print(f"    --temp-db {output_db} \\")
+    print("    --final-dir <final_images_directory>")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ai/backfill_project_phase1b_user_data.py
+++ b/scripts/ai/backfill_project_phase1b_user_data.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""
+Phase 1B: Backfill User Ground Truth into Temp Database
+
+This script:
+1. Reads all records from temp database (which has AI predictions)
+2. For each group, finds which image exists in final directory
+3. Extracts crop coordinates via template matching
+4. Updates database with user ground truth
+5. Calculates selection_match and crop_match metrics
+
+Input: temp database (with AI predictions, user fields NULL)
+Output: temp database (complete with both AI and user data)
+
+Usage:
+    python scripts/ai/backfill_project_phase1b_user_data.py \\
+        --temp-db data/training/ai_training_decisions/mojo3_backfill_temp.db \\
+        --final-dir mojo3/
+"""
+
+import argparse
+import json
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+from PIL import Image
+from tqdm import tqdm
+
+# Add project root to path
+WORKSPACE = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(WORKSPACE))
+
+
+def extract_crop_coordinates(
+    original_path: Path, cropped_path: Path, confidence_threshold: float = 0.8
+) -> Optional[Tuple[List[float], float]]:
+    """Extract crop coordinates using template matching."""
+    try:
+        original = cv2.imread(str(original_path))
+        cropped = cv2.imread(str(cropped_path))
+
+        if original is None or cropped is None:
+            return None
+
+        orig_height, orig_width = original.shape[:2]
+        crop_height, crop_width = cropped.shape[:2]
+
+        if crop_width > orig_width or crop_height > orig_height:
+            return None
+
+        original_gray = cv2.cvtColor(original, cv2.COLOR_BGR2GRAY)
+        cropped_gray = cv2.cvtColor(cropped, cv2.COLOR_BGR2GRAY)
+
+        result = cv2.matchTemplate(original_gray, cropped_gray, cv2.TM_CCOEFF_NORMED)
+        min_val, max_val, min_loc, max_loc = cv2.minMaxLoc(result)
+
+        confidence = max_val
+        if confidence < confidence_threshold:
+            return None
+
+        x1, y1 = max_loc
+        x2, y2 = x1 + crop_width, y1 + crop_height
+
+        # Normalize coordinates
+        coords = [x1 / orig_width, y1 / orig_height, x2 / orig_width, y2 / orig_height]
+
+        return coords, confidence
+
+    except Exception:
+        return None
+
+
+def coords_match(
+    coords1: List[float], coords2: List[float], tolerance: float = 0.05
+) -> bool:
+    """Check if two coordinate sets match within tolerance."""
+    if not coords1 or not coords2:
+        return False
+
+    if len(coords1) != 4 or len(coords2) != 4:
+        return False
+
+    for c1, c2 in zip(coords1, coords2):
+        if abs(c1 - c2) > tolerance:
+            return False
+
+    return True
+
+
+def find_user_selected_image(
+    group_images: List[str], group_directory: str, final_dir: Path
+) -> Optional[Tuple[int, Path]]:
+    """Find which image from the group exists in final directory."""
+    # Try each image in the group
+    for idx, filename in enumerate(group_images):
+        # Search recursively in final directory
+        matches = list(final_dir.glob(f"**/{filename}"))
+        if matches:
+            return idx, matches[0]
+
+    return None
+
+
+def get_all_records_from_db(db_path: Path) -> List[Dict]:
+    """Read all records from database."""
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """
+        SELECT group_id, images, directory, ai_selected_index, ai_crop_coords
+        FROM ai_decisions
+        ORDER BY timestamp
+    """
+    )
+
+    results = cursor.fetchall()
+    conn.close()
+
+    records = []
+    for (
+        group_id,
+        images_json,
+        directory,
+        ai_selected_index,
+        ai_crop_coords_json,
+    ) in results:
+        try:
+            images = json.loads(images_json)
+            ai_crop_coords = (
+                json.loads(ai_crop_coords_json) if ai_crop_coords_json else None
+            )
+
+            records.append(
+                {
+                    "group_id": group_id,
+                    "images": images,
+                    "directory": directory,
+                    "ai_selected_index": ai_selected_index,
+                    "ai_crop_coords": ai_crop_coords,
+                }
+            )
+        except Exception as e:
+            print(f"  ⚠️  Error parsing record {group_id}: {e}")
+            continue
+
+    return records
+
+
+def update_record_with_user_data(
+    db_path: Path,
+    group_id: str,
+    user_selected_index: int,
+    user_action: str,
+    final_crop_coords: Optional[List[float]],
+    selection_match: bool,
+    crop_match: Optional[bool],
+    dry_run: bool = False,
+):
+    """Update database record with user ground truth."""
+    if dry_run:
+        return  # Don't actually update in dry-run mode
+
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    crop_coords_json = json.dumps(final_crop_coords) if final_crop_coords else None
+    crop_timestamp = datetime.now().isoformat() + "Z" if final_crop_coords else None
+
+    cursor.execute(
+        """
+        UPDATE ai_decisions
+        SET user_selected_index = ?,
+            user_action = ?,
+            final_crop_coords = ?,
+            crop_timestamp = ?,
+            selection_match = ?,
+            crop_match = ?
+        WHERE group_id = ?
+    """,
+        (
+            user_selected_index,
+            user_action,
+            crop_coords_json,
+            crop_timestamp,
+            selection_match,
+            crop_match,
+            group_id,
+        ),
+    )
+
+    conn.commit()
+    conn.close()
+
+
+def process_records(
+    records: List[Dict], final_dir: Path, db_path: Path, dry_run: bool = False
+):
+    """Process all records and backfill user data."""
+    stats = {
+        "total_records": len(records),
+        "found_in_final": 0,
+        "not_in_final": 0,
+        "crop_coords_extracted": 0,
+        "crop_coords_failed": 0,
+        "selection_matches": 0,
+        "crop_matches": 0,
+        "errors": 0,
+    }
+
+    samples = []  # Collect sample updates for dry-run
+
+    print(f"\n🔄 Processing {len(records)} records...")
+
+    for record in tqdm(records, desc="Backfilling" if not dry_run else "Analyzing"):
+        try:
+            group_id = record["group_id"]
+            images = record["images"]
+            directory = record["directory"]
+            ai_selected_index = record["ai_selected_index"]
+            ai_crop_coords = record["ai_crop_coords"]
+
+            # Find which image exists in final directory
+            result = find_user_selected_image(images, directory, final_dir)
+
+            if not result:
+                # User rejected/skipped this entire group
+                stats["not_in_final"] += 1
+                update_record_with_user_data(
+                    db_path,
+                    group_id,
+                    user_selected_index=None,
+                    user_action="skip",
+                    final_crop_coords=None,
+                    selection_match=None,
+                    crop_match=None,
+                    dry_run=dry_run,
+                )
+                continue
+
+            user_selected_index, final_image_path = result
+            stats["found_in_final"] += 1
+
+            # Calculate selection match
+            selection_match = (
+                (ai_selected_index == user_selected_index)
+                if ai_selected_index is not None
+                else None
+            )
+            if selection_match:
+                stats["selection_matches"] += 1
+
+            # Extract crop coordinates from physical files
+            original_path = Path(directory) / images[user_selected_index]
+
+            crop_result = extract_crop_coordinates(original_path, final_image_path)
+
+            if crop_result:
+                final_crop_coords, confidence = crop_result
+                stats["crop_coords_extracted"] += 1
+
+                # Calculate crop match
+                crop_match = (
+                    coords_match(ai_crop_coords, final_crop_coords)
+                    if ai_crop_coords
+                    else None
+                )
+                if crop_match:
+                    stats["crop_matches"] += 1
+            else:
+                final_crop_coords = None
+                crop_match = None
+                stats["crop_coords_failed"] += 1
+
+            # Collect sample for dry-run
+            if dry_run and len(samples) < 10:
+                samples.append(
+                    {
+                        "group_id": group_id,
+                        "ai_selected": ai_selected_index,
+                        "user_selected": user_selected_index,
+                        "selection_match": selection_match,
+                        "crop_match": crop_match,
+                    }
+                )
+
+            # Update database
+            update_record_with_user_data(
+                db_path,
+                group_id,
+                user_selected_index=user_selected_index,
+                user_action="crop",
+                final_crop_coords=final_crop_coords,
+                selection_match=selection_match,
+                crop_match=crop_match,
+                dry_run=dry_run,
+            )
+
+        except Exception as e:
+            print(f"  ⚠️  Error processing {record.get('group_id', 'unknown')}: {e}")
+            stats["errors"] += 1
+
+    return stats, samples
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Backfill user ground truth into temp database"
+    )
+    parser.add_argument(
+        "--temp-db",
+        required=True,
+        help="Path to temp database (e.g., data/training/ai_training_decisions/mojo3_backfill_temp.db)",
+    )
+    parser.add_argument(
+        "--final-dir",
+        required=True,
+        help="Directory containing final cropped images (e.g., mojo3/)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without modifying database",
+    )
+    args = parser.parse_args()
+
+    temp_db = Path(args.temp_db)
+    final_dir = Path(args.final_dir)
+
+    print("=" * 80)
+    print("PHASE 1B: Backfill User Ground Truth")
+    print("=" * 80)
+    print(f"Mode: {'DRY RUN' if args.dry_run else 'LIVE'}")
+    print(f"Final images: {final_dir}")
+    print(f"Database: {temp_db}")
+
+    # Check database exists
+    if not temp_db.exists():
+        print(f"\n❌ ERROR: Temp database not found: {temp_db}")
+        print("   Run Phase 1A first to create it.")
+        return
+
+    # Check final directory exists
+    if not final_dir.exists():
+        print(f"\n❌ ERROR: Final directory not found: {final_dir}")
+        return
+
+    # Read all records
+    records = get_all_records_from_db(temp_db)
+    print(f"\nFound {len(records)} records to process")
+
+    # Process records
+    stats, samples = process_records(records, final_dir, temp_db, dry_run=args.dry_run)
+
+    # Print statistics
+    print(f"\n{'=' * 80}")
+    print("STATISTICS")
+    print(f"{'=' * 80}")
+    print(f"Total records:             {stats['total_records']:,}")
+    print(f"Found in final:            {stats['found_in_final']:,}")
+    print(f"Not in final (skipped):    {stats['not_in_final']:,}")
+    print(f"Crop coords extracted:     {stats['crop_coords_extracted']:,}")
+    print(f"Crop coords failed:        {stats['crop_coords_failed']:,}")
+    print("")
+
+    if stats["found_in_final"] > 0:
+        sel_pct = stats["selection_matches"] / stats["found_in_final"] * 100
+        print(
+            f"Selection matches:         {stats['selection_matches']:,} / {stats['found_in_final']:,} ({sel_pct:.1f}%)"
+        )
+
+    if stats["crop_coords_extracted"] > 0:
+        crop_pct = stats["crop_matches"] / stats["crop_coords_extracted"] * 100
+        print(
+            f"Crop matches:              {stats['crop_matches']:,} / {stats['crop_coords_extracted']:,} ({crop_pct:.1f}%)"
+        )
+
+    print(f"Errors:                    {stats['errors']:,}")
+
+    if args.dry_run and samples:
+        print("\n📋 SAMPLE UPDATES (first 10):")
+        for i, sample in enumerate(samples, 1):
+            match_str = "✅ MATCH" if sample["selection_match"] else "❌ MISMATCH"
+            print(f"  {i}. {sample['group_id']}")
+            print(
+                f"     AI selected: {sample['ai_selected']}, User selected: {sample['user_selected']} - {match_str}"
+            )
+
+    if args.dry_run:
+        print("\n💡 DRY RUN - No changes made to database")
+        print("   Run without --dry-run to apply changes")
+    else:
+        print("\n✅ PHASE 1B COMPLETE!")
+        print("\nDatabase now contains:")
+        print(f"  - AI predictions for {len(records):,} groups")
+        print(f"  - User ground truth for {stats['found_in_final']:,} groups")
+        if stats["found_in_final"] > 0:
+            print(f"  - Selection accuracy: {sel_pct:.1f}%")
+        print("\nNext step: Run Phase 2 to compare with real database")
+        print("  python scripts/ai/backfill_project_phase2_compare.py \\")
+        print(f"    --temp-db {temp_db} \\")
+        print("    --real-db <path_to_real_database>")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ai/backfill_project_phase2_compare.py
+++ b/scripts/ai/backfill_project_phase2_compare.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""
+Backfill Phase 2: Compare and Merge Databases
+
+This script compares the temporary backfill database with the real database
+and merges data intelligently:
+- Adds records that exist in temp but not in real database
+- Fills NULL fields in real database from temp database
+- NEVER overwrites existing data in real database
+- Preserves all existing AI predictions and timestamps
+
+Usage:
+    python scripts/ai/backfill_project_phase2_compare.py \\
+        --temp-db data/training/ai_training_decisions/mojo3_backfill_temp.db \\
+        --real-db data/training/ai_training_decisions/mojo3.db \\
+        --dry-run
+"""
+
+import argparse
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def get_all_records(db_path: Path) -> Dict[str, Dict[str, Any]]:
+    """Load all records from database, keyed by group_id."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT * FROM ai_decisions")
+
+    records = {}
+    for row in cursor:
+        record = dict(row)
+        records[record["group_id"]] = record
+
+    conn.close()
+    return records
+
+
+def build_image_to_record_map(records: Dict[str, Dict[str, Any]]) -> Dict[str, str]:
+    """Build a map from image filename to group_id for finding matches."""
+    image_map = {}
+    for group_id, record in records.items():
+        try:
+            images = json.loads(record["images"])
+            for img_path in images:
+                # Extract just the filename (no directory)
+                filename = Path(img_path).name
+                image_map[filename] = group_id
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return image_map
+
+
+def coords_are_close(
+    coords1_json: Optional[str], coords2_json: Optional[str], tolerance: float = 0.01
+) -> bool:
+    """
+    Check if two crop coordinate sets are within tolerance (1% default).
+
+    Args:
+        coords1_json: JSON string like "[0.1, 0.2, 0.9, 0.8]"
+        coords2_json: JSON string like "[0.1, 0.2, 0.9, 0.8]"
+        tolerance: Allowed deviation (0.01 = 1%)
+
+    Returns:
+        True if coordinates are within tolerance
+    """
+    if coords1_json is None or coords2_json is None:
+        return False
+
+    try:
+        coords1 = json.loads(coords1_json)
+        coords2 = json.loads(coords2_json)
+
+        if len(coords1) != 4 or len(coords2) != 4:
+            return False
+
+        # Check each coordinate
+        for c1, c2 in zip(coords1, coords2):
+            if abs(c1 - c2) > tolerance:
+                return False
+
+        return True
+    except Exception:
+        return False
+
+
+def compare_records(
+    temp_record: Dict[str, Any], real_record: Optional[Dict[str, Any]]
+) -> Tuple[str, Dict[str, Any]]:
+    """
+    Compare temp and real records and determine merge action.
+
+    CRITICAL RULES:
+    - NEVER overwrite timestamps (timestamp, crop_timestamp)
+    - Temp database is source of truth for: final_crop_coords, user_selected_index, user_action
+    - Use 1% tolerance when comparing coordinates
+    - Only update if coordinates differ beyond tolerance
+
+    Returns:
+        (action, data) where action is:
+        - 'add': Record doesn't exist in real DB, add it
+        - 'fill_nulls': Record exists but has NULL values to fill
+        - 'update_coords': Crop coordinates differ beyond tolerance
+        - 'skip': Record exists and is complete, no changes needed
+    """
+    if real_record is None:
+        return ("add", temp_record)
+
+    # Check which fields need to be filled or updated
+    fields_to_update = {}
+
+    # CRITICAL: Check if final_crop_coords differ (with tolerance)
+    temp_coords = temp_record.get("final_crop_coords")
+    real_coords = real_record.get("final_crop_coords")
+
+    # If both have coords, check if they're different (beyond tolerance)
+    if temp_coords and real_coords:
+        if not coords_are_close(temp_coords, real_coords, tolerance=0.01):
+            # Coordinates differ beyond 1% tolerance - temp is source of truth
+            fields_to_update["final_crop_coords"] = temp_coords
+            # Recalculate crop_match with new coordinates
+            if temp_record.get("crop_match") is not None:
+                fields_to_update["crop_match"] = temp_record["crop_match"]
+
+    # If real DB has NULL coords but temp has coords, fill them
+    if real_coords is None and temp_coords is not None:
+        fields_to_update["final_crop_coords"] = temp_coords
+
+    # AI prediction fields - only fill if NULL in real DB (never overwrite existing AI data)
+    if (
+        real_record["ai_selected_index"] is None
+        and temp_record["ai_selected_index"] is not None
+    ):
+        fields_to_update["ai_selected_index"] = temp_record["ai_selected_index"]
+
+    if (
+        real_record["ai_crop_coords"] is None
+        and temp_record["ai_crop_coords"] is not None
+    ):
+        fields_to_update["ai_crop_coords"] = temp_record["ai_crop_coords"]
+
+    if (
+        real_record["ai_confidence"] is None
+        and temp_record["ai_confidence"] is not None
+    ):
+        fields_to_update["ai_confidence"] = temp_record["ai_confidence"]
+
+    # Match fields - only fill if NULL in real DB
+    if (
+        real_record["selection_match"] is None
+        and temp_record["selection_match"] is not None
+    ):
+        fields_to_update["selection_match"] = temp_record["selection_match"]
+
+    if real_record["crop_match"] is None and temp_record["crop_match"] is not None:
+        fields_to_update["crop_match"] = temp_record["crop_match"]
+
+    # User action - only fill if NULL or empty in real DB
+    if (
+        real_record["user_action"] is None or real_record["user_action"] == ""
+    ) and temp_record["user_action"]:
+        fields_to_update["user_action"] = temp_record["user_action"]
+
+    # User selected index - only fill if NULL in real DB
+    if (
+        real_record.get("user_selected_index") is None
+        and temp_record.get("user_selected_index") is not None
+    ):
+        fields_to_update["user_selected_index"] = temp_record["user_selected_index"]
+
+    if fields_to_update:
+        # Determine if this is a coordinate correction or null filling
+        if "final_crop_coords" in fields_to_update and real_coords is not None:
+            return (
+                "update_coords",
+                {
+                    "group_id": real_record["group_id"],
+                    "updates": fields_to_update,
+                    "old_coords": real_coords,
+                },
+            )
+        else:
+            return (
+                "fill_nulls",
+                {"group_id": real_record["group_id"], "updates": fields_to_update},
+            )
+
+    return ("skip", {})
+
+
+def add_record(cursor: sqlite3.Cursor, record: Dict[str, Any], dry_run: bool = True):
+    """Add a new record to the real database."""
+    if dry_run:
+        return
+
+    cursor.execute(
+        """
+        INSERT INTO ai_decisions (
+            group_id, timestamp, project_id, directory, batch_number,
+            images, ai_selected_index, ai_crop_coords, ai_confidence,
+            user_selected_index, user_action, final_crop_coords,
+            crop_timestamp, image_width, image_height,
+            selection_match, crop_match
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """,
+        (
+            record["group_id"],
+            record["timestamp"],
+            record["project_id"],
+            record["directory"],
+            record["batch_number"],
+            record["images"],
+            record["ai_selected_index"],
+            record["ai_crop_coords"],
+            record["ai_confidence"],
+            record["user_selected_index"],
+            record["user_action"],
+            record["final_crop_coords"],
+            record["crop_timestamp"],
+            record["image_width"],
+            record["image_height"],
+            record["selection_match"],
+            record["crop_match"],
+        ),
+    )
+
+
+def fill_null_fields(
+    cursor: sqlite3.Cursor, group_id: str, updates: Dict[str, Any], dry_run: bool = True
+):
+    """
+    Update NULL fields in existing record.
+
+    CRITICAL: NEVER update timestamp or crop_timestamp fields.
+    """
+    if dry_run:
+        return
+
+    # Remove any timestamp fields if they somehow got included
+    updates_safe = {
+        k: v for k, v in updates.items() if k not in ["timestamp", "crop_timestamp"]
+    }
+
+    if not updates_safe:
+        return  # Nothing to update
+
+    set_clauses = []
+    values = []
+
+    for field, value in updates_safe.items():
+        set_clauses.append(f"{field} = ?")
+        values.append(value)
+
+    values.append(group_id)  # For WHERE clause
+
+    sql = f"UPDATE ai_decisions SET {', '.join(set_clauses)} WHERE group_id = ?"
+    cursor.execute(sql, values)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Phase 2: Compare and merge backfill data"
+    )
+    parser.add_argument(
+        "--temp-db", required=True, help="Path to temporary backfill database"
+    )
+    parser.add_argument(
+        "--real-db", required=True, help="Path to real production database"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without modifying database",
+    )
+    args = parser.parse_args()
+
+    temp_db_path = Path(args.temp_db)
+    real_db_path = Path(args.real_db)
+
+    print("=" * 80)
+    print("PHASE 2: DATABASE COMPARISON & MERGE")
+    print("=" * 80)
+    print(f"Temp DB: {temp_db_path}")
+    print(f"Real DB: {real_db_path}")
+    print(
+        f"Mode: {'DRY RUN (no changes)' if args.dry_run else 'LIVE (will modify database)'}"
+    )
+    print()
+
+    # Verify files exist
+    if not temp_db_path.exists():
+        print(f"❌ ERROR: Temp database not found: {temp_db_path}")
+        return
+
+    if not real_db_path.exists():
+        print(f"❌ ERROR: Real database not found: {real_db_path}")
+        return
+
+    print("Loading databases...")
+    temp_records = get_all_records(temp_db_path)
+    real_records = get_all_records(real_db_path)
+
+    print(f"  Temp DB: {len(temp_records):,} records")
+    print(f"  Real DB: {len(real_records):,} records")
+    print()
+
+    # Build image filename to group_id maps for matching
+    print("Building image filename maps...")
+    temp_image_map = build_image_to_record_map(temp_records)
+    real_image_map = build_image_to_record_map(real_records)
+
+    print(f"  Temp DB: {len(temp_image_map):,} unique images")
+    print(f"  Real DB: {len(real_image_map):,} unique images")
+    print()
+
+    # Find overlapping images (same filename in both databases)
+    overlapping_images = set(temp_image_map.keys()) & set(real_image_map.keys())
+    print(f"  Overlapping images: {len(overlapping_images):,}")
+    print()
+
+    # Compare all records
+    print("Comparing records...")
+    actions = {"add": [], "fill_nulls": [], "update_coords": [], "skip": []}
+
+    # Track which temp records matched with real records
+    matched_temp_group_ids = set()
+
+    # First, check for overlapping images and compare their records
+    for img_filename in overlapping_images:
+        temp_group_id = temp_image_map[img_filename]
+        real_group_id = real_image_map[img_filename]
+
+        temp_record = temp_records[temp_group_id]
+        real_record = real_records[real_group_id]
+
+        action, data = compare_records(temp_record, real_record)
+        actions[action].append((real_group_id, data))  # Use real group_id for updates
+        matched_temp_group_ids.add(temp_group_id)
+
+    # Then, add any temp records that didn't match (new groups to add)
+    for temp_group_id, temp_record in temp_records.items():
+        if temp_group_id not in matched_temp_group_ids:
+            actions["add"].append((temp_group_id, temp_record))
+
+    # Display summary
+    print()
+    print("=" * 80)
+    print("COMPARISON RESULTS")
+    print("=" * 80)
+    print(f"Records to ADD:       {len(actions['add']):,}")
+    print(f"Records to UPDATE:    {len(actions['fill_nulls']):,}")
+    print(
+        f"Coords to CORRECT:    {len(actions['update_coords']):,} ⚠️  (temp is source of truth)"
+    )
+    print(f"Records to SKIP:      {len(actions['skip']):,}")
+    print()
+
+    # Show sample actions
+    if actions["add"]:
+        print("Sample records to ADD (first 5):")
+        for i, (group_id, record) in enumerate(actions["add"][:5]):
+            print(f"  {i+1}. {group_id}")
+            print(
+                f"     - AI: index={record['ai_selected_index']}, confidence={record['ai_confidence']:.2f}"
+            )
+            print(
+                f"     - User: action={record['user_action']}, coords={record['final_crop_coords'][:50] if record['final_crop_coords'] else None}"
+            )
+        if len(actions["add"]) > 5:
+            print(f"  ... and {len(actions['add']) - 5:,} more")
+        print()
+
+    if actions["update_coords"]:
+        print("⚠️  Sample COORDINATE CORRECTIONS (first 5):")
+        print(
+            "    (Temp coordinates extracted from physical images are source of truth)"
+        )
+        for i, (group_id, data) in enumerate(actions["update_coords"][:5]):
+            print(f"  {i+1}. {group_id}")
+            print(f"     - OLD: {data['old_coords'][:60]}...")
+            new_coords = data["updates"]["final_crop_coords"]
+            print(f"     - NEW: {new_coords[:60]}...")
+        if len(actions["update_coords"]) > 5:
+            print(f"  ... and {len(actions['update_coords']) - 5:,} more")
+        print()
+
+    if actions["fill_nulls"]:
+        print("Sample records to UPDATE (first 5):")
+        for i, (group_id, data) in enumerate(actions["fill_nulls"][:5]):
+            print(f"  {i+1}. {group_id}")
+            for field, value in data["updates"].items():
+                if isinstance(value, str) and len(value) > 50:
+                    value = value[:50] + "..."
+                print(f"     - Fill {field}: {value}")
+        if len(actions["fill_nulls"]) > 5:
+            print(f"  ... and {len(actions['fill_nulls']) - 5:,} more")
+        print()
+
+    # Check for records in real DB but not in temp (shouldn't happen, just informational)
+    real_only = set(real_records.keys()) - set(temp_records.keys())
+    if real_only:
+        print(f"Records in real DB but NOT in temp: {len(real_only):,}")
+        print("  (These will be left unchanged - this is expected)")
+        print()
+
+    # Execute changes
+    if args.dry_run:
+        print("=" * 80)
+        print("🔍 DRY RUN COMPLETE - No changes made")
+        print("=" * 80)
+        print()
+        print("To actually merge the data, run without --dry-run:")
+        print("  python scripts/ai/backfill_project_phase2_compare.py \\")
+        print(f"    --temp-db {temp_db_path} \\")
+        print(f"    --real-db {real_db_path}")
+        print()
+        print("⚠️  RECOMMENDATION: Review the samples above before proceeding!")
+    else:
+        print("=" * 80)
+        print("⚠️  APPLYING CHANGES TO REAL DATABASE")
+        print("=" * 80)
+
+        conn = sqlite3.connect(str(real_db_path))
+        cursor = conn.cursor()
+
+        try:
+            # Add new records
+            print(f"Adding {len(actions['add']):,} new records...")
+            for group_id, record in actions["add"]:
+                add_record(cursor, record, dry_run=False)
+
+            # Update existing records (fill NULLs)
+            print(
+                f"Updating {len(actions['fill_nulls']):,} existing records (filling NULLs)..."
+            )
+            for group_id, data in actions["fill_nulls"]:
+                fill_null_fields(
+                    cursor, data["group_id"], data["updates"], dry_run=False
+                )
+
+            # Correct coordinates
+            print(
+                f"Correcting {len(actions['update_coords']):,} crop coordinates (temp is source of truth)..."
+            )
+            for group_id, data in actions["update_coords"]:
+                fill_null_fields(
+                    cursor, data["group_id"], data["updates"], dry_run=False
+                )
+
+            conn.commit()
+            print()
+            print("✅ MERGE COMPLETE!")
+            print()
+            print("Summary:")
+            print(f"  - Added: {len(actions['add']):,} records")
+            print(f"  - Updated: {len(actions['fill_nulls']):,} records (filled NULLs)")
+            print(
+                f"  - Corrected: {len(actions['update_coords']):,} records (fixed coordinates)"
+            )
+            print(f"  - Skipped: {len(actions['skip']):,} records (already complete)")
+            print(
+                f"  - Total in real DB: {len(real_records) + len(actions['add']):,} records"
+            )
+
+        except Exception as e:
+            print(f"❌ ERROR during merge: {e}")
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+        print()
+        print("=" * 80)
+        print("🎉 BACKFILL COMPLETE!")
+        print("=" * 80)
+        print()
+        print("Next steps:")
+        print("  1. Validate the merged data:")
+        print("     python scripts/ai/validate_training_data.py <project_id>")
+        print("  2. Check AI performance stats:")
+        print(f"     sqlite3 {real_db_path}")
+        print(
+            "     SELECT COUNT(*), AVG(selection_match), AVG(crop_match) FROM ai_decisions;"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ai/check_missing_database_records.py
+++ b/scripts/ai/check_missing_database_records.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Check which images in the final directory are missing from the database.
+"""
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Set
+
+# Paths
+WORKSPACE = Path(__file__).resolve().parents[2]
+
+
+def get_all_images_from_directory(dir_path: Path) -> Set[str]:
+    """Get all image filenames from directory recursively."""
+    patterns = ["**/*.png", "**/*.jpg", "**/*.jpeg"]
+    images = set()
+    for pattern in patterns:
+        for img_path in dir_path.glob(pattern):
+            images.add(img_path.name)
+    return images
+
+
+def get_all_images_from_database(db_path: Path) -> Set[str]:
+    """Get all image filenames referenced in the database."""
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT images FROM ai_decisions")
+    results = cursor.fetchall()
+    conn.close()
+
+    images = set()
+    for (images_json,) in results:
+        try:
+            img_list = json.loads(images_json)
+            for img in img_list:
+                images.add(img)
+        except Exception:
+            continue
+
+    return images
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Find images in directory not in database"
+    )
+    parser.add_argument("--image-dir", required=True, help="Directory with images")
+    parser.add_argument("--database", required=True, help="Database path")
+
+    args = parser.parse_args()
+
+    image_dir = Path(args.image_dir)
+    db_path = Path(args.database)
+
+    print(f"Scanning images in: {image_dir}")
+    dir_images = get_all_images_from_directory(image_dir)
+    print(f"Found {len(dir_images)} images in directory")
+
+    print(f"\nQuerying database: {db_path}")
+    db_images = get_all_images_from_database(db_path)
+    print(f"Found {len(db_images)} unique images in database")
+
+    # Find images in directory but not in database
+    missing_from_db = dir_images - db_images
+
+    # Find images in database but not in directory
+    missing_from_dir = db_images - dir_images
+
+    print(f"\n{'=' * 80}")
+    print("RESULTS")
+    print(f"{'=' * 80}")
+    print(f"Images in directory:        {len(dir_images):,}")
+    print(f"Images in database:         {len(db_images):,}")
+    print(f"In directory but NOT in DB: {len(missing_from_db):,} ⚠️")
+    print(f"In database but NOT in dir: {len(missing_from_dir):,}")
+
+    if missing_from_db:
+        print(f"\n⚠️  {len(missing_from_db):,} IMAGES IN DIRECTORY ARE NOT IN DATABASE!")
+        print("\nSample missing images (first 20):")
+        for i, img in enumerate(sorted(missing_from_db)[:20], 1):
+            print(f"  {i}. {img}")
+
+        if len(missing_from_db) > 20:
+            print(f"  ... and {len(missing_from_db) - 20:,} more")
+
+    if missing_from_dir:
+        print(f"\n⚠️  {len(missing_from_dir):,} images in database are NOT in directory")
+        print("(These may have been deleted or moved)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ai/verify_and_correct_crop_coords.py
+++ b/scripts/ai/verify_and_correct_crop_coords.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""
+Verify and Correct Crop Coordinates from Physical Images
+
+SOURCE OF TRUTH: Physical cropped images on disk
+VERIFICATION TARGET: Database final_crop_coords
+
+This script:
+1. Scans all cropped images in the project directory
+2. Extracts ACTUAL crop coordinates via template matching with originals
+3. Compares against database coordinates
+4. Reports mismatches
+5. Optionally corrects database to match physical reality
+
+CRITICAL: This treats the physical files as ground truth, not the database.
+
+Usage:
+    # Generate inspection report (dry-run)
+    python scripts/ai/verify_and_correct_crop_coords.py mojo3 \\
+        --cropped-dir mojo3/ \\
+        --original-dir /Volumes/T7Shield/Eros/original/mojo3 \\
+        --database data/training/ai_training_decisions/mojo3.db \\
+        --dry-run
+    
+    # Correct database mismatches
+    python scripts/ai/verify_and_correct_crop_coords.py mojo3 \\
+        --cropped-dir mojo3/ \\
+        --original-dir /Volumes/T7Shield/Eros/original/mojo3 \\
+        --database data/training/ai_training_decisions/mojo3.db \\
+        --execute
+"""
+
+import argparse
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+from PIL import Image
+
+# Paths
+WORKSPACE = Path(__file__).resolve().parents[2]
+
+
+def extract_crop_coordinates(
+    original_path: Path, cropped_path: Path, confidence_threshold: float = 0.8
+) -> Optional[Tuple[List[float], float]]:
+    """
+    Extract crop coordinates using template matching.
+
+    Returns: (normalized_coords, confidence) or None
+    """
+    try:
+        # Load images
+        original = cv2.imread(str(original_path))
+        cropped = cv2.imread(str(cropped_path))
+
+        if original is None or cropped is None:
+            return None
+
+        # Get dimensions
+        orig_height, orig_width = original.shape[:2]
+        crop_height, crop_width = cropped.shape[:2]
+
+        # Skip if cropped image is larger than original
+        if crop_width > orig_width or crop_height > orig_height:
+            return None
+
+        # Convert to grayscale for matching
+        original_gray = cv2.cvtColor(original, cv2.COLOR_BGR2GRAY)
+        cropped_gray = cv2.cvtColor(cropped, cv2.COLOR_BGR2GRAY)
+
+        # Template matching
+        result = cv2.matchTemplate(original_gray, cropped_gray, cv2.TM_CCOEFF_NORMED)
+        min_val, max_val, min_loc, max_loc = cv2.minMaxLoc(result)
+
+        confidence = max_val
+        if confidence < confidence_threshold:
+            return None
+
+        # Extract coordinates
+        x1, y1 = max_loc
+        x2, y2 = x1 + crop_width, y1 + crop_height
+
+        # Normalize coordinates [0, 1]
+        x1_norm = x1 / orig_width
+        y1_norm = y1 / orig_height
+        x2_norm = x2 / orig_width
+        y2_norm = y2 / orig_height
+
+        coords = [x1_norm, y1_norm, x2_norm, y2_norm]
+
+        return coords, confidence
+
+    except Exception as e:
+        print(f"    [!] Error extracting coordinates: {e}")
+        return None
+
+
+def coords_match(
+    coords1: List[float], coords2: List[float], tolerance: float = 0.001
+) -> bool:
+    """Check if two coordinate sets match within tolerance."""
+    if not coords1 or not coords2:
+        return False
+
+    if len(coords1) != 4 or len(coords2) != 4:
+        return False
+
+    for c1, c2 in zip(coords1, coords2):
+        if abs(c1 - c2) > tolerance:
+            return False
+
+    return True
+
+
+def format_coords(coords: List[float]) -> str:
+    """Format coordinates for display."""
+    return "[" + ", ".join(f"{x:.4f}" for x in coords) + "]"
+
+
+class CropCoordinateValidator:
+    """Validates and corrects crop coordinates against physical images."""
+
+    def __init__(
+        self,
+        project_id: str,
+        cropped_dir: Path,
+        original_dir: Path,
+        database_path: Path,
+        dry_run: bool = True,
+    ):
+        self.project_id = project_id
+        self.cropped_dir = Path(cropped_dir)
+        self.original_dir = Path(original_dir)
+        self.database_path = Path(database_path)
+        self.dry_run = dry_run
+
+        # Validation
+        if not self.cropped_dir.exists():
+            raise ValueError(f"Cropped directory not found: {self.cropped_dir}")
+        if not self.original_dir.exists():
+            raise ValueError(f"Original directory not found: {self.original_dir}")
+        if not self.database_path.exists():
+            raise ValueError(f"Database not found: {self.database_path}")
+
+    def scan_cropped_images(self) -> List[Path]:
+        """Find all cropped images recursively."""
+        patterns = ["**/*.png", "**/*.jpg", "**/*.jpeg"]
+        images = []
+        for pattern in patterns:
+            images.extend(self.cropped_dir.glob(pattern))
+        return sorted(images)
+
+    def get_crop_records_from_database(self) -> List[Dict]:
+        """Get all crop action records from database."""
+        conn = sqlite3.connect(str(self.database_path))
+        cursor = conn.cursor()
+
+        cursor.execute(
+            """
+            SELECT group_id, images, user_selected_index, final_crop_coords, user_action
+            FROM ai_decisions
+            WHERE user_action = 'crop'
+            ORDER BY timestamp
+        """
+        )
+
+        results = cursor.fetchall()
+        conn.close()
+
+        records = []
+        for group_id, images_json, user_idx, final_coords, user_action in results:
+            try:
+                images = json.loads(images_json)
+                selected_filename = images[user_idx] if user_idx < len(images) else None
+                coords = json.loads(final_coords) if final_coords else None
+
+                if selected_filename:
+                    records.append(
+                        {
+                            "group_id": group_id,
+                            "images": images,
+                            "user_selected_index": user_idx,
+                            "selected_filename": selected_filename,
+                            "final_crop_coords": coords,
+                            "user_action": user_action,
+                        }
+                    )
+            except Exception as e:
+                print(f"Error parsing record {group_id}: {e}")
+                continue
+
+        return records
+        """Get database record for an image filename."""
+        conn = sqlite3.connect(str(self.database_path))
+        cursor = conn.cursor()
+
+        # Search for record containing this filename in images JSON array
+        cursor.execute(
+            """
+            SELECT group_id, images, user_selected_index, final_crop_coords, user_action
+            FROM ai_decisions
+            WHERE images LIKE ?
+        """,
+            (f"%{filename}%",),
+        )
+
+        results = cursor.fetchall()
+        conn.close()
+
+        # Find exact match in images array
+        for group_id, images_json, user_idx, final_coords, user_action in results:
+            try:
+                images = json.loads(images_json)
+                if filename in images:
+                    selected_filename = (
+                        images[user_idx] if user_idx < len(images) else None
+                    )
+                    coords = json.loads(final_coords) if final_coords else None
+
+                    return {
+                        "group_id": group_id,
+                        "images": images,
+                        "user_selected_index": user_idx,
+                        "selected_filename": selected_filename,
+                        "final_crop_coords": coords,
+                        "user_action": user_action,
+                        "is_selected": (selected_filename == filename),
+                    }
+            except Exception:
+                continue
+
+        return None
+
+    def validate_and_correct(self) -> Dict:
+        """Validate all cropped images and report/correct mismatches."""
+        print(f"\n{'=' * 80}")
+        print(f"CROP COORDINATE VALIDATION - {self.project_id}")
+        print(f"{'=' * 80}")
+        print(f"Mode: {'DRY RUN' if self.dry_run else 'LIVE CORRECTION'}")
+        print(f"Cropped images: {self.cropped_dir}")
+        print(f"Original images: {self.original_dir}")
+        print(f"Database: {self.database_path}")
+
+        # Get all crop records from database
+        print("\nQuerying database for crop actions...")
+        crop_records = self.get_crop_records_from_database()
+        print(f"Found {len(crop_records)} crop actions in database")
+
+        results = {
+            "total_crop_records": len(crop_records),
+            "cropped_file_found": 0,
+            "cropped_file_not_found": 0,
+            "original_not_found": 0,
+            "coordinates_match": 0,
+            "coordinates_mismatch": 0,
+            "template_match_failed": 0,
+            "mismatches": [],
+            "corrections_made": 0,
+        }
+
+        for i, record in enumerate(crop_records, 1):
+            filename = record["selected_filename"]
+
+            # Progress indicator every 100 images
+            if i % 100 == 0:
+                print(
+                    f"\n[{i}/{len(crop_records)}] Progress: {i/len(crop_records)*100:.1f}% complete"
+                )
+
+            print(f"\n[{i}/{len(crop_records)}] Validating: {filename}")
+
+            # Find cropped file (recursive search)
+            cropped_matches = list(self.cropped_dir.glob(f"**/{filename}"))
+            if not cropped_matches:
+                print(f"    ⚠️  Cropped file not found in {self.cropped_dir}")
+                results["cropped_file_not_found"] += 1
+                continue
+
+            cropped_path = cropped_matches[0]
+            results["cropped_file_found"] += 1
+
+            # Find original image (recursive search in original dir)
+            original_matches = list(self.original_dir.glob(f"**/{filename}"))
+            if not original_matches:
+                print(f"    ⚠️  Original not found: {filename}")
+                results["original_not_found"] += 1
+                continue
+
+            original_path = original_matches[0]
+
+            # Extract coordinates from physical images
+            match_result = extract_crop_coordinates(original_path, cropped_path)
+            if not match_result:
+                print("    ❌ Template matching failed")
+                results["template_match_failed"] += 1
+                continue
+
+            physical_coords, confidence = match_result
+            db_coords = record["final_crop_coords"]
+
+            print(
+                f"    Physical coords: {format_coords(physical_coords)} (confidence: {confidence:.4f})"
+            )
+            print(
+                f"    Database coords: {format_coords(db_coords) if db_coords else 'NULL'}"
+            )
+
+            # Compare coordinates
+            if coords_match(physical_coords, db_coords):
+                print("    ✅ Match!")
+                results["coordinates_match"] += 1
+            else:
+                print("    ⚠️  MISMATCH!")
+                results["coordinates_mismatch"] += 1
+                results["mismatches"].append(
+                    {
+                        "filename": filename,
+                        "group_id": record["group_id"],
+                        "physical_coords": physical_coords,
+                        "database_coords": db_coords,
+                        "confidence": confidence,
+                    }
+                )
+
+                # Correct if not dry run
+                if not self.dry_run:
+                    if self.update_database_coords(record["group_id"], physical_coords):
+                        print("    ✅ Corrected in database")
+                        results["corrections_made"] += 1
+                    else:
+                        print("    ❌ Failed to update database")
+
+        return results
+
+    def update_database_coords(self, group_id: str, coords: List[float]) -> bool:
+        """Update database with corrected coordinates."""
+        try:
+            conn = sqlite3.connect(str(self.database_path))
+            cursor = conn.cursor()
+
+            coords_json = json.dumps(coords)
+            timestamp = datetime.now().isoformat() + "Z"
+
+            cursor.execute(
+                """
+                UPDATE ai_decisions
+                SET final_crop_coords = ?,
+                    crop_timestamp = ?
+                WHERE group_id = ?
+            """,
+                (coords_json, timestamp, group_id),
+            )
+
+            conn.commit()
+            conn.close()
+            return True
+        except Exception as e:
+            print(f"    [!] Database update error: {e}")
+            return False
+
+    def print_summary(self, results: Dict):
+        """Print validation summary."""
+        print(f"\n{'=' * 80}")
+        print("VALIDATION SUMMARY")
+        print(f"{'=' * 80}")
+        print(f"Total crop records in DB:   {results['total_crop_records']}")
+        print(f"Cropped file found:         {results['cropped_file_found']}")
+        print(f"Cropped file not found:     {results['cropped_file_not_found']}")
+        print(f"Original not found:         {results['original_not_found']}")
+        print(f"Template matching failed:   {results['template_match_failed']}")
+        print("")
+        print(f"Coordinates match:          {results['coordinates_match']} ✅")
+        print(f"Coordinates MISMATCH:       {results['coordinates_mismatch']} ⚠️")
+
+        if results["coordinates_mismatch"] > 0:
+            print("\n⚠️  MISMATCHES DETECTED:")
+            for mismatch in results["mismatches"][:10]:  # Show first 10
+                print(f"   {mismatch['filename']}")
+                print(f"     Physical: {format_coords(mismatch['physical_coords'])}")
+                print(
+                    f"     Database: {format_coords(mismatch['database_coords']) if mismatch['database_coords'] else 'NULL'}"
+                )
+
+            if len(results["mismatches"]) > 10:
+                print(f"   ... and {len(results['mismatches']) - 10} more")
+
+        if not self.dry_run:
+            print(f"\nCorrections made:           {results['corrections_made']}")
+        else:
+            print("\n💡 Run with --execute to apply corrections")
+
+        print(f"\n{'=' * 80}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Verify and correct crop coordinates from physical images"
+    )
+    parser.add_argument("project_id", help="Project ID (e.g., mojo3)")
+    parser.add_argument(
+        "--cropped-dir", required=True, help="Directory with cropped images"
+    )
+    parser.add_argument(
+        "--original-dir", required=True, help="Directory with original images"
+    )
+    parser.add_argument("--database", required=True, help="Path to SQLite database")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Report only, don't modify database"
+    )
+    parser.add_argument(
+        "--execute", action="store_true", help="Apply corrections to database"
+    )
+
+    args = parser.parse_args()
+
+    # Default to dry-run unless --execute specified
+    dry_run = not args.execute
+
+    validator = CropCoordinateValidator(
+        project_id=args.project_id,
+        cropped_dir=args.cropped_dir,
+        original_dir=args.original_dir,
+        database_path=args.database,
+        dry_run=dry_run,
+    )
+
+    results = validator.validate_and_correct()
+    validator.print_summary(results)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Major Changes:
- Generalized 3 backfill scripts to work with any project (not just mojo3)
  - backfill_project_phase1a_ai_predictions.py (AI predictions from originals)
  - backfill_project_phase1b_user_data.py (user ground truth from finals)
  - backfill_project_phase2_compare.py (intelligent merge with real DB)
  - All now accept command-line args for directories and databases

Documentation:
- Complete rewrite of BACKFILL_QUICK_START.md with new 3-phase process
  - Documents Phase 1A (AI predictions), Phase 1B (user ground truth), Phase 2 (merge)
  - Includes real mojo3 example with actual results (6,468 records)
  - Emphasizes: physical images = source of truth, never copy AI predictions as user data
  - Explains user_action semantics (approve/crop/reject, NO 'skip')
  - Documents coordinate tolerances (2% approve detection, 1% comparison, 5% metrics)
- Updated TECHNICAL_KNOWLEDGE_BASE.md backfill section
- Updated AI_TRAINING_PLAYBOOK.md with new process
- Marked 3 old backfill docs as OBSOLETE with pointers to new guide
- Removed all CSV references from current documentation

Data Integrity:
- Successfully backfilled mojo3.db: 1,762 → 6,468 records
- Preserved all timestamps from real database
- AI performance: 53.6% selection accuracy, 4.3% crop accuracy
- No data corruption: coordinates matched within 1% tolerance

Scripts Added:
- backfill_mojo3_phase1a_ai_predictions.py (project-specific, kept for reference)
- backfill_mojo3_phase1b_user_data.py (project-specific, kept for reference)
- backfill_mojo3_phase2_compare.py (project-specific, kept for reference)
- check_missing_database_records.py (utility for finding discrepancies)
- verify_and_correct_crop_coords.py (validation tool)

## PR Summary

- Title: <concise, action-oriented>
- Branch: <feature/..., fix/..., chore/...>
- Linked Issue (if any): #

## What Changed
- <≤80-char bullet>
- <≤80-char bullet>
- <≤80-char bullet>

## Commits
- <short-sha> (<full-sha>): <one-line summary>

## Files Touched
- `path/to/file1`
- `path/to/file2`

## How to Verify
1. <exact command or URL>
2. <expected output>
3. <where to look>

## Links
- Direct PR: <this page URL>
- Compare view (optional): https://github.com/<org>/<repo>/compare/main...<branch>

## Reviewer Notes
- Breaking changes? <yes/no>
- Data migration? <yes/no>
- Safety concerns? <yes/no>


