### PR TITLE
Disable pedantic linting rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,11 @@ ignore = [
   "D102",     # Missing method docstring (enforced selectively)
   "D103",     # Missing function docstring (enforced selectively)
   "D104",     # Missing package docstring
+  "D105",     # Missing docstring in magic methods (unnecessary noise)
   "D107",     # Missing __init__ docstring
+  "D415",     # First line should end with period (pedantic)
+  "D205",     # 1 blank line required between summary and description (annoying)
+  "D212",     # Multi-line docstring summary should start at first line (style preference)
   
   # Arguments - allow flexibility
   "ARG001",   # Unused function argument (sometimes needed for interface compatibility)

--- a/scripts/file_tracker.py
+++ b/scripts/file_tracker.py
@@ -342,10 +342,10 @@ def read_log(
 
 def print_recent_activity(hours: int = 24):
     """Print recent file activity in a human-readable format."""
-    from datetime import timedelta  # noqa: PLC0415
+    from datetime import timedelta
 
     entries = read_log()
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     cutoff = now - timedelta(hours=hours)
 
     print(f"\n=== File Activity (Last {hours} hours) ===")  # noqa: T201


### PR DESCRIPTION
- Add D415 (docstring periods), D105 (magic method docs), D205, D212 to ignore
- Fix timezone.utc reference in file_tracker.py (use UTC from imports)
- Keep important rules: BLE001, DTZ, S, F (catch real bugs)

Now linting focuses on actual bugs, not cosmetic nitpicks.

## PR Summary

- Title: <concise, action-oriented>
- Branch: <feature/..., fix/..., chore/...>
- Linked Issue (if any): #

## What Changed
- <≤80-char bullet>
- <≤80-char bullet>
- <≤80-char bullet>

## Commits
- <short-sha> (<full-sha>): <one-line summary>

## Files Touched
- `path/to/file1`
- `path/to/file2`

## How to Verify
1. <exact command or URL>
2. <expected output>
3. <where to look>

## Links
- Direct PR: <this page URL>
- Compare view (optional): https://github.com/<org>/<repo>/compare/main...<branch>

## Reviewer Notes
- Breaking changes? <yes/no>
- Data migration? <yes/no>
- Safety concerns? <yes/no>


