### PR TITLE
Improve Raptor prompts with template sections

### DIFF
--- a/prompts/raptor_phase_a_sonnet.md
+++ b/prompts/raptor_phase_a_sonnet.md
@@ -57,3 +57,11 @@ Copy code
 
 Be surgical, explicit, and opinionated—no vague advice.
 ```
+
+---
+
+## TARGET FILE FOR THIS REVIEW
+
+**Replace this line with the file path** (e.g., `scripts/01_ai_assisted_reviewer.py`)
+
+[PASTE FILE PATH HERE]

--- a/prompts/raptor_phase_b_codex.md
+++ b/prompts/raptor_phase_b_codex.md
@@ -34,3 +34,19 @@ OUTPUT FORMAT:
 (score 0–10 for reliability; brief rationale)
 
 Be concrete and code-centric—your goal is to raise confidence that no silent failures remain.
+
+---
+
+## TARGET FILE FOR THIS REVIEW
+
+**Replace with file path** (e.g., `scripts/01_ai_assisted_reviewer.py`)
+
+[PASTE FILE PATH HERE]
+
+---
+
+## PHASE A OUTPUT (to verify)
+
+**Paste Phase A findings below:**
+
+[PASTE PHASE A RESULTS HERE]

--- a/prompts/raptor_phase_c_safety.md
+++ b/prompts/raptor_phase_c_safety.md
@@ -34,3 +34,27 @@ INSTRUCTIONS:
 Be concise but brutally honest.
 Prefer specific, actionable comments over generalizations.
 Do not sugarcoat — the goal is reliability over speed.
+
+---
+
+## TARGET FILE FOR THIS REVIEW
+
+**Replace with file path** (e.g., `scripts/01_ai_assisted_reviewer.py`)
+
+[PASTE FILE PATH HERE]
+
+---
+
+## PHASE A OUTPUT
+
+**Paste Phase A findings:**
+
+[PASTE PHASE A RESULTS HERE]
+
+---
+
+## PHASE B OUTPUT
+
+**Paste Phase B verification:**
+
+[PASTE PHASE B RESULTS HERE]


### PR DESCRIPTION
- Add clear template sections at bottom of all 3 phase prompts
- Phase A: Just paste file path
- Phase B: Paste file path + Phase A results
- Phase C: Paste file path + Phase A + Phase B results
- No more manual editing needed - just fill in the blanks

Makes workflow faster and less error-prone.

## PR Summary

- Title: <concise, action-oriented>
- Branch: <feature/..., fix/..., chore/...>
- Linked Issue (if any): #

## What Changed
- <≤80-char bullet>
- <≤80-char bullet>
- <≤80-char bullet>

## Commits
- <short-sha> (<full-sha>): <one-line summary>

## Files Touched
- `path/to/file1`
- `path/to/file2`

## How to Verify
1. <exact command or URL>
2. <expected output>
3. <where to look>

## Links
- Direct PR: <this page URL>
- Compare view (optional): https://github.com/<org>/<repo>/compare/main...<branch>

## Reviewer Notes
- Breaking changes? <yes/no>
- Data migration? <yes/no>
- Safety concerns? <yes/no>


