### PR TITLE
Apply Raptor Phase 8 fixes to Finish Project + Add TODO automation

### DIFF
--- a/Documents/core/CURRENT_TODO_LIST.md
+++ b/Documents/core/CURRENT_TODO_LIST.md
@@ -75,6 +75,27 @@
 - Token usage spreads across days/weeks
 - Creates comprehensive audit trail
 
+**Future Automation:**
+
+- [ ] **Automate Raptor review workflow using API endpoints**
+  - **Goal:** Replace manual copy/paste workflow with automated API calls
+  - **Resources:** Erik has ChatGPT and Claude API endpoints available
+  - **Workflow to automate:**
+    1. Phase A: Call Claude Sonnet 4.5 API with Phase A prompt + target file
+    2. Parse Phase A output, extract findings section
+    3. Phase B: Call GPT-5 Codex API with Phase B prompt + Phase A results
+    4. Parse Phase B output, extract validation summary
+    5. Phase C: Call GPT-5 API with Phase C prompt + all prior results
+    6. Generate complete review document automatically
+    7. Optionally: Auto-apply diffs if confidence score meets threshold
+  - **Benefits:**
+    - Remove manual copy/paste (slowest part of workflow)
+    - Enable batch processing of multiple scripts overnight
+    - Consistent prompt execution (no human error in pasting)
+    - Generate structured JSON output for dashboard integration
+  - **Priority:** LOW (current manual workflow is working well)
+  - **Estimated Effort:** 2-3 hours for API integration script
+
 ---
 
 ### AI Predictions Backfill (HIGH PRIORITY)

--- a/reviews/raptor_review_20251101T012014Z.md
+++ b/reviews/raptor_review_20251101T012014Z.md
@@ -1,0 +1,692 @@
+# Meta-Prompt Raptor Review
+
+_Date:_ 2025-11-01 01:01:58Z UTC
+
+## Phase A – Claude Sonnet 4.5 (Max Mode)
+
+Prompt file: /Users/eriksjaastad/projects/image-workflow/prompts/raptor_phase_a_sonnet.md
+
+# RAPTOR Phase A Review: `scripts/07_finish_project.py`
+
+**Reviewer:** Claude Sonnet 4.5 (Raptor Phase A)  
+**Date:** 2025-11-01T01:20:14Z  
+**Target:** `scripts/07_finish_project.py`  
+**Project:** image-workflow-scripts (Python 3.11)
+
+---
+
+## === FINDINGS ===
+
+### 🔴 Critical: Silent Exception Handlers (4 instances)
+
+The script contains **multiple silent exception handlers** that violate the project's core reliability rules:
+
+1. **Line 277-279** (`print_cleanup_summary`): Bare `except Exception: pass` with comment "Fail open: don't block finishing if summary fails"
+
+   - **Risk:** If the cleanup summary calculation crashes, the user sees nothing. This could hide serious issues like corrupted allowlist files, import errors, or filesystem problems.
+   - **Production Impact:** User might finalize a project without realizing the delivery ZIP is missing critical files or includes wrong files.
+
+2. **Line 307-308** (manifest backup): `except Exception: pass` when backing up manifest
+
+   - **Risk:** Silently fails to create backup before overwriting manifest. If the write on line 309 corrupts the file, there's no backup to restore from.
+   - **Production Impact:** Data loss risk - manifest corruption with no recovery path.
+
+3. **Line 344-346** (manifest reload): Bare `except Exception:` sets `finished_at = None` and continues
+
+   - **Risk:** If manifest becomes corrupt after writing, the script silently continues with empty metrics rather than alerting the user.
+   - **Production Impact:** User thinks project is finished, but manifest might be corrupted.
+
+4. **Line 422-423** (interactive mode): `except Exception: continue` while listing active projects
+   - **Risk:** Corrupt manifest files are silently skipped. User never knows there's a problem.
+   - **Production Impact:** Hidden data corruption - user can't see or fix broken manifests.
+
+### 🟡 Medium: Broad Exception Handlers Without Logging (4 instances)
+
+These handlers return error status but don't log before returning:
+
+1. **Line 112-113** (`run_prezip_stager`): `except Exception as e:` returns error dict
+2. **Line 146-147** (`finish_project`): `except Exception as e:` returns error dict
+3. **Line 375-376** (archive bins): `except Exception as e:` prints warning but doesn't log
+4. **Line 447-449** (interactive mode): `except Exception as e:` prints error but doesn't log
+
+**Risk:** No audit trail. When debugging production failures, there's no log to consult.
+
+### 🟡 Medium: Suppressed Linter Warning
+
+- **Line 342-343**: `except Exception as e: # noqa: BLE001` for .gitignore update
+  - Intentionally suppresses broad exception check
+  - Prints warning but doesn't re-raise
+  - Should still follow logging best practices even if suppressed
+
+### 🔵 Info: Process Execution Without Check Flag
+
+- **Line 86**: `subprocess.run(cmd, capture_output=True, text=True, check=False)`
+  - Relies on manual `returncode` checking instead of automatic exception
+  - This is acceptable but less fail-fast than `check=True`
+
+---
+
+## === DIFFS (max 5) ===
+
+### DIFF 1: Add Logging to `run_prezip_stager` Exception Handler
+
+**Priority:** Critical  
+**Impact:** Audit trail for subprocess failures
+
+```diff
+--- a/scripts/07_finish_project.py
++++ b/scripts/07_finish_project.py
+@@ -21,6 +21,7 @@
+ import argparse
+ import json
++import logging
+ import subprocess
+ import sys
+ from datetime import datetime, timezone
+@@ -28,6 +29,8 @@
+ from typing import Any, Dict
+
++logger = logging.getLogger(__name__)
++
+ # Ensure project root on import path for local package imports
+ _ROOT = Path(__file__).resolve().parents[1]
+ if str(_ROOT) not in sys.path:
+@@ -109,7 +112,9 @@
+
+         return {"status": "success", "stager_output": output, "dry_run": dry_run}
+
+-    except Exception as e:
++    except Exception as e:
++        logger.error(f"Failed to run prezip_stager: {e}", exc_info=True)
++        # Return error dict for CLI handling (this is a CLI script)
+         return {"status": "error", "message": f"Failed to run prezip_stager: {e}"}
+```
+
+---
+
+### DIFF 2: Fix Silent Exception in `print_cleanup_summary`
+
+**Priority:** Critical  
+**Impact:** User visibility of cleanup calculation failures
+
+```diff
+--- a/scripts/07_finish_project.py
++++ b/scripts/07_finish_project.py
+@@ -274,9 +274,12 @@
+                 for n in notable:
+                     print(f"  - {n}")
+             print("\n[DRY RUN] ✅ Ready to finalize project")
+-        except Exception:
+-            # Fail open: don't block finishing if summary fails
+-            pass
++        except Exception as e:
++            logger.error(f"Failed to generate cleanup summary: {e}", exc_info=True)
++            print("\n[DRY RUN] ⚠️  Failed to generate cleanup summary")
++            print(f"[DRY RUN] Error: {e}")
++            print("[DRY RUN] This is a preview error only - the actual operation may still work")
++            # Don't raise - summary is informational only
+
+     result = run_prezip_stager(
+         project_id=project_id,
+```
+
+---
+
+### DIFF 3: Fix Silent Exception in Manifest Backup
+
+**Priority:** Critical  
+**Impact:** Data loss prevention - backup failures must be visible
+
+```diff
+--- a/scripts/07_finish_project.py
++++ b/scripts/07_finish_project.py
+@@ -300,11 +300,16 @@
+             if finished_at and manifest.get("status") != "finished":
+                 manifest["status"] = "finished"
+                 # Backup and write
+                 backup = manifest_path.with_suffix(".project.json.bak")
+                 try:
+                     import shutil
+-
+                     shutil.copy2(manifest_path, backup)
+-                except Exception:
+-                    pass
++                    logger.info(f"Backed up manifest to {backup}")
++                except Exception as e:
++                    logger.error(f"Failed to backup manifest to {backup}: {e}", exc_info=True)
++                    print(f"⚠️  WARNING: Failed to backup manifest before update: {e}")
++                    print(f"⚠️  Manifest will be updated without backup - cancel now if concerned (Ctrl+C)")
++                    import time
++                    time.sleep(3)  # Give user time to cancel
++                    # Continue anyway - backup failure shouldn't block the operation
+                 manifest_path.write_text(
+                     json.dumps(manifest, indent=2), encoding="utf-8"
+                 )
+```
+
+---
+
+### DIFF 4: Add Logging to Manifest Reload Exception
+
+**Priority:** High  
+**Impact:** Visibility of post-write manifest corruption
+
+```diff
+--- a/scripts/07_finish_project.py
++++ b/scripts/07_finish_project.py
+@@ -340,9 +345,11 @@
+                         else:
+                             print(f"⚠️  Found start marker but not end marker for {project_id} in .gitignore")
+                     else:
+                         print(f"⚠️  Project {project_id} not found in .gitignore")
+-            except Exception as e:  # noqa: BLE001
++            except Exception as e:  # noqa: BLE001
++                logger.warning(f"Failed to update .gitignore: {e}")
+                 print(f"⚠️  Failed to update .gitignore: {e}")
+-        except Exception:
++        except Exception as e:
++            logger.error(f"Failed to reload manifest after update: {e}", exc_info=True)
+             finished_at = None
+             stager_metrics = {}
+     else:
+```
+
+---
+
+### DIFF 5: Fix Silent Exception in Interactive Project Listing
+
+**Priority:** Medium  
+**Impact:** Visibility of corrupt manifests
+
+```diff
+--- a/scripts/07_finish_project.py
++++ b/scripts/07_finish_project.py
+@@ -410,7 +410,7 @@
+         manifests = list(projects_dir.glob("*.project.json"))
+         active_projects = []
+
+         for manifest_path in manifests:
+             try:
+                 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+@@ -419,8 +419,10 @@
+                     title = manifest.get("title", project_id)
+                     initial = manifest.get("counts", {}).get("initialImages", "?")
+                     started = manifest.get("startedAt", "Unknown")
+                     active_projects.append((project_id, title, initial, started))
+-            except Exception:
+-                continue
++            except Exception as e:
++                logger.warning(f"Failed to read manifest {manifest_path.name}: {e}")
++                print(f"  ⚠️  Skipped corrupt manifest: {manifest_path.name} ({e})")
++                # Continue - don't block listing other projects
+
+         if active_projects:
+             print("Active projects:")
+```
+
+---
+
+## === TESTS ===
+
+### Test 1: Verify Logging on subprocess Failure
+
+```python
+import logging
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import pytest
+
+def test_run_prezip_stager_logs_subprocess_exception(caplog):
+    """Verify that subprocess exceptions are logged before returning error."""
+    from scripts.finish_project import run_prezip_stager
+
+    with caplog.at_level(logging.ERROR):
+        with patch('subprocess.run') as mock_run:
+            mock_run.side_effect = FileNotFoundError("prezip_stager.py not found")
+
+            result = run_prezip_stager(
+                project_id="test",
+                content_dir=Path("/tmp/test"),
+                output_zip=Path("/tmp/test.zip"),
+                dry_run=True
+            )
+
+    assert result["status"] == "error"
+    assert "Failed to run prezip_stager" in result["message"]
+    assert len(caplog.records) == 1
+    assert "Failed to run prezip_stager" in caplog.records[0].message
+    assert caplog.records[0].exc_info is not None  # Logged with traceback
+```
+
+---
+
+### Test 2: Verify Backup Failure is Logged and Warned
+
+```python
+def test_manifest_backup_failure_is_logged(tmp_path, caplog, capsys):
+    """Verify that manifest backup failures are logged and shown to user."""
+    from scripts.finish_project import finish_project
+
+    # Create test manifest
+    manifest = {
+        "projectId": "test",
+        "status": "active",
+        "paths": {"root": str(tmp_path)},
+        "counts": {"initialImages": 10}
+    }
+    manifest_path = tmp_path / "data" / "projects" / "test.project.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(json.dumps(manifest))
+
+    with caplog.at_level(logging.ERROR):
+        with patch('shutil.copy2') as mock_copy:
+            mock_copy.side_effect = PermissionError("Read-only filesystem")
+            with patch('time.sleep'):  # Don't actually sleep in tests
+                # This should log the backup failure
+                result = finish_project("test", dry_run=False)
+
+    # Check logging
+    assert any("Failed to backup manifest" in rec.message for rec in caplog.records)
+
+    # Check user warning
+    captured = capsys.readouterr()
+    assert "WARNING: Failed to backup manifest" in captured.out
+```
+
+---
+
+### Test 3: Verify Corrupt Manifest is Logged in Interactive Mode
+
+```python
+def test_interactive_mode_logs_corrupt_manifests(tmp_path, caplog, capsys):
+    """Verify corrupt manifests are logged and shown, not silently skipped."""
+    from scripts.finish_project import interactive_mode
+
+    # Create corrupt manifest
+    projects_dir = tmp_path / "data" / "projects"
+    projects_dir.mkdir(parents=True)
+    corrupt = projects_dir / "bad.project.json"
+    corrupt.write_text("{invalid json")
+
+    with caplog.at_level(logging.WARNING):
+        with patch('builtins.input', side_effect=["", ""]):  # Empty inputs to exit
+            with pytest.raises(SystemExit):
+                interactive_mode()
+
+    # Should log the corrupt manifest
+    assert any("Failed to read manifest bad.project.json" in rec.message
+               for rec in caplog.records)
+
+    # Should show user-visible warning
+    captured = capsys.readouterr()
+    assert "Skipped corrupt manifest: bad.project.json" in captured.out
+```
+
+---
+
+### Test 4: Verify Cleanup Summary Failure is Logged
+
+```python
+def test_cleanup_summary_exception_is_logged(tmp_path, caplog):
+    """Verify that exceptions in print_cleanup_summary are logged."""
+    from scripts.finish_project import finish_project
+
+    # Create minimal valid project
+    manifest = {
+        "projectId": "test",
+        "status": "active",
+        "paths": {"root": str(tmp_path)},
+    }
+    manifest_path = tmp_path / "data" / "projects" / "test.project.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(json.dumps(manifest))
+
+    with caplog.at_level(logging.ERROR):
+        with patch('scripts.finish_project.load_allowlist') as mock_load:
+            mock_load.side_effect = RuntimeError("Allowlist file corrupt")
+
+            result = finish_project("test", dry_run=True)
+
+    # Should log the error
+    assert any("Failed to generate cleanup summary" in rec.message
+               for rec in caplog.records)
+```
+
+---
+
+### Test 5: Verify Archive Exceptions are Logged
+
+```python
+def test_archive_bins_exception_is_logged(tmp_path, caplog):
+    """Verify that archive_project_bins exceptions are logged."""
+    from scripts.finish_project import finish_project
+
+    # Setup project (assumes we're not in dry_run and project is finished)
+    manifest = {
+        "projectId": "test",
+        "status": "finished",
+        "finishedAt": "2025-11-01T00:00:00Z",
+        "paths": {"root": str(tmp_path)},
+    }
+    manifest_path = tmp_path / "data" / "projects" / "test.project.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(json.dumps(manifest))
+
+    with caplog.at_level(logging.ERROR):
+        with patch('scripts.finish_project.ProjectArchiver') as mock_archiver:
+            mock_instance = MagicMock()
+            mock_instance.archive_project.side_effect = RuntimeError("Bins DB corrupt")
+            mock_archiver.return_value = mock_instance
+
+            result = finish_project("test", dry_run=False)
+
+    # Should log archive errors
+    assert any("archive" in rec.message.lower() for rec in caplog.records)
+    # Operation should continue despite archive failure
+    assert result["archive"]["status"] == "error"
+```
+
+---
+
+## === CHECKLIST ===
+
+### Immediate Actions (Before Next Production Run)
+
+1. **Apply all 5 diffs** to add logging to exception handlers
+2. **Set up logging configuration** in the script's `if __name__ == "__main__"` block:
+   ```python
+   logging.basicConfig(
+       level=logging.INFO,
+       format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+       handlers=[
+           logging.FileHandler('data/file_operations_logs/finish_project.log'),
+           logging.StreamHandler()
+       ]
+   )
+   ```
+3. **Add the 5 pytest tests** to a new file `scripts/tests/test_07_finish_project.py`
+4. **Run tests** to verify exception paths raise properly: `pytest scripts/tests/test_07_finish_project.py -v`
+
+### Short-term Improvements (Next Sprint)
+
+5. **Add heartbeat/success verification** to `finish_project()`:
+
+   - After writing manifest, verify the written file is valid JSON
+   - After creating ZIP, verify it exists and is non-empty
+   - Consider adding a "verification mode" that reads back all changes
+
+6. **Consider fail-fast for critical paths**:
+
+   - Line 307-308: Should backup failure block the operation? (Currently continues)
+   - Line 277-279: Should cleanup summary failure prevent finalization? (Currently continues)
+   - Document the "fail open" vs "fail closed" decision for each exception
+
+7. **Add integration test** that runs the full workflow:
+   - Create test project
+   - Run finish_project (dry_run=False)
+   - Verify manifest updated correctly
+   - Verify ZIP created
+   - Verify .gitignore updated
+   - Clean up test artifacts
+
+### Long-term Reliability (Backlog)
+
+8. **Add pre-commit hook** to enforce logging in exception handlers:
+
+   - Extend `.pre-commit-config.yaml` to check for `except.*: pass` patterns
+   - Already have custom hook for broad exceptions, ensure it catches these cases
+
+9. **Set up CI verification**:
+
+   - Run all tests on every commit
+   - Lint check with Ruff (already configured)
+   - Consider adding coverage requirement (80%+ for critical scripts)
+
+10. **Add operation logging to FileTracker**:
+
+    - Log finish_project operations to audit trail
+    - Track: manifest updates, ZIP creation, .gitignore changes, archive operations
+    - Format: `tracker.track_file_operation('finish_project', manifest_path, None, metadata={'dry_run': dry_run})`
+
+11. **Consider using `subprocess.run(check=True)`** on line 86:
+    - Would raise `CalledProcessError` automatically instead of manual checking
+    - More fail-fast, less code
+    - Current approach (check=False) is acceptable but more verbose
+
+---
+
+## Summary
+
+**Root Cause of Fragility:** Multiple silent exception handlers create invisible failure modes. When this script runs in production, errors are swallowed without logging, making debugging impossible and hiding data corruption.
+
+**Critical Risk:** The manifest backup failure (line 307-308) is the highest risk - if the subsequent write corrupts the manifest, there's no backup and no warning.
+
+**Production Impact:** User could finalize a project thinking everything succeeded, when actually:
+
+- Manifest backup failed (no recovery if corrupted)
+- Cleanup summary crashed (wrong files in ZIP)
+- Archive operation failed (bins not archived)
+- Corrupt manifests hidden from view
+
+**Fix Strategy:** Surgical patches to add logging + error visibility. All exceptions should be logged before being swallowed. The script is allowed to continue in some cases ("fail open"), but only after logging and warning the user.
+
+---
+
+**Confidence Level:** High - These are textbook reliability anti-patterns that match the project's documented failure history (silent failures, no data collected for several days).
+
+## Phase B – GPT-5 Codex Verification
+
+Prompt file: /Users/eriksjaastad/projects/image-workflow/prompts/raptor_phase_b_codex.md
+[1 tool called]
+
+=== VALIDATION SUMMARY ===
+
+- ✅ Diff 1 (run_prezip_stager logging): Adds module-level logger and logs subprocess failures with traceback; behavior and return shape stay unchanged.
+- ✅ Diff 2 (cleanup summary handler): Logs the failure, surfaces a dry-run warning, and still fails open so users can continue.
+- ✅ Diff 3 (manifest backup): Logs both success and failure, warns the operator, and gives a brief pause without blocking the workflow.
+- ✅ Diff 4 (.gitignore / manifest reload): Ensures both update attempts emit structured logs; manifest reload still degrades gracefully.
+- ✅ Diff 5 (interactive manifest listing): Corrupt manifests now trigger warnings in both log and CLI output while preserving the loop.
+
+=== SUGGESTED ADDITIONS ===
+
+```diff
+@@
+-    except Exception as e:
+-        return {"status": "error", "message": f"Failed to read manifest: {e}"}
++    except Exception as e:
++        logger.error(
++            f"Failed to read manifest {manifest_path.name}: {e}", exc_info=True
++        )
++        return {"status": "error", "message": f"Failed to read manifest: {e}"}
+@@
+-        except Exception as e:
+-            print(f"  ⚠️  Archive failed: {e}")
++        except Exception as e:
++            logger.error(f"Archive failed for {project_id}: {e}", exc_info=True)
++            print(f"  ⚠️  Archive failed: {e}")
+```
+
+```diff
+@@
+ def main():
+-    """Main entry point."""
++    """Main entry point."""
++    log_dir = Path("data/file_operations_logs")
++    log_dir.mkdir(parents=True, exist_ok=True)
++    logging.basicConfig(
++        level=logging.INFO,
++        format="%(asctime)s %(name)s %(levelname)s %(message)s",
++        handlers=[
++            logging.FileHandler(log_dir / "finish_project.log"),
++            logging.StreamHandler(),
++        ],
++    )
+```
+
+=== TEST RECOMMENDATIONS ===
+
+- Keep the proposed pytest coverage for subprocess failure, manifest backup failure, cleanup summary failure, corrupt manifest listing, and archive failure; verify each test fails before the corresponding fix and passes afterward.
+- Add a quick regression asserting the manifest-read exception now logs (use `caplog` to confirm `exc_info` is set).
+
+=== CONFIDENCE REPORT ===
+
+- 8/10 – Patches eliminate the critical silent failures; remaining work is tightening the earlier medium-risk handlers and wiring logging config.
+
+## Phase C – Human Safety Check
+
+Prompt file: /Users/eriksjaastad/projects/image-workflow/prompts/raptor_phase_c_safety.md
+
+### === MERGE SAFETY REVIEW ===
+
+- High-risk files (name + why)
+
+  - scripts/07_finish_project.py: Multiple silent/broad exception handlers hide failures; manifest backup can fail silently before overwrite (data-loss risk); missing logging configuration leads to zero audit trail; corrupt manifests are silently skipped in interactive mode.
+
+- Subtle issues that automated tools might miss (reasoning)
+
+  - **Silent fail-open paths**: Backup, cleanup summary, and manifest reload paths continue without surfacing failures; acceptable only if loudly logged and user-warned.
+  - **Logger without config**: Adding `logger = logging.getLogger(__name__)` is insufficient; without `basicConfig`/handlers, logs may be dropped.
+  - **Process execution**: `subprocess.run(..., check=False)` relies on manual checks; a forgotten return-code check will silently pass.
+  - **.gitignore handler**: Broad exception with `# noqa: BLE001` masks issues; must log/warn to avoid invisible failures.
+  - **Operational audit**: No FileTracker audit calls for critical operations (manifest update, archive, gitignore change); weak forensic trail if something goes wrong.
+  - **Post-write verification**: Manifest write isn’t validated by a read-back; if corrupted mid-write, the next step degrades silently.
+
+- Suggested micro-patches or assertions (unified diff or pseudo-code)
+
+```diff
+--- a/scripts/07_finish_project.py
++++ b/scripts/07_finish_project.py
+@@
+ import argparse
+ import json
++import logging
+ import subprocess
+ import sys
+ from datetime import datetime, timezone
+@@
+-from typing import Any, Dict
++from typing import Any, Dict
++
++logger = logging.getLogger(__name__)
+@@
+-    except Exception as e:
+-        return {"status": "error", "message": f"Failed to run prezip_stager: {e}"}
++    except Exception as e:
++        logger.error(f"Failed to run prezip_stager: {e}", exc_info=True)
++        return {"status": "error", "message": f"Failed to run prezip_stager: {e}"}
+@@
+-        except Exception:
+-            # Fail open: don't block finishing if summary fails
+-            pass
++        except Exception as e:
++            logger.error(f"Failed to generate cleanup summary: {e}", exc_info=True)
++            print("\n[DRY RUN] ⚠️  Failed to generate cleanup summary")
++            print(f"[DRY RUN] Error: {e}")
++            print("[DRY RUN] This is a preview error only - the actual operation may still work")
+@@
+-                try:
+-                    import shutil
+-
+-                    shutil.copy2(manifest_path, backup)
+-                except Exception:
+-                    pass
++                try:
++                    import shutil
++                    shutil.copy2(manifest_path, backup)
++                    logger.info(f"Backed up manifest to {backup}")
++                except Exception as e:
++                    logger.error(f"Failed to backup manifest to {backup}: {e}", exc_info=True)
++                    print(f"⚠️  WARNING: Failed to backup manifest before update: {e}")
++                    print("⚠️  Manifest will be updated without backup - cancel now if concerned (Ctrl+C)")
++                    import time; time.sleep(3)
+@@
+-            except Exception as e:  # noqa: BLE001
+-                print(f"⚠️  Failed to update .gitignore: {e}")
++            except Exception as e:  # noqa: BLE001
++                logger.warning(f"Failed to update .gitignore: {e}")
++                print(f"⚠️  Failed to update .gitignore: {e}")
+-        except Exception:
++        except Exception as e:
++            logger.error(f"Failed to reload manifest after update: {e}", exc_info=True)
+             finished_at = None
+             stager_metrics = {}
+@@
+-        for manifest_path in manifests:
++        for manifest_path in manifests:
+             try:
+                 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+@@
+-            except Exception:
+-                continue
++            except Exception as e:
++                logger.warning(f"Failed to read manifest {manifest_path.name}: {e}")
++                print(f"  ⚠️  Skipped corrupt manifest: {manifest_path.name} ({e})")
++                # Continue - don't block listing other projects
+```
+
+```diff
+@@
+-    except Exception as e:
+-        return {"status": "error", "message": f"Failed to read manifest: {e}"}
++    except Exception as e:
++        logger.error(f"Failed to read manifest {manifest_path.name}: {e}", exc_info=True)
++        return {"status": "error", "message": f"Failed to read manifest: {e}"}
+@@
+-        except Exception as e:
+-            print(f"  ⚠️  Archive failed: {e}")
++        except Exception as e:
++            logger.error(f"Archive failed for {project_id}: {e}", exc_info=True)
++            print(f"  ⚠️  Archive failed: {e}")
+```
+
+```diff
+@@
+-def main():
+-    """Main entry point."""
++def main():
++    """Main entry point."""
++    log_dir = Path("data/file_operations_logs")
++    log_dir.mkdir(parents=True, exist_ok=True)
++    logging.basicConfig(
++        level=logging.INFO,
++        format="%(asctime)s %(name)s %(levelname)s %(message)s",
++        handlers=[
++            logging.FileHandler(log_dir / "finish_project.log"),
++            logging.StreamHandler(),
++        ],
++    )
+```
+
+Additional verification hardening (pseudo-code):
+
+```python
+# After manifest_path.write_text(...)
+try:
+    json.loads(manifest_path.read_text(encoding="utf-8"))
+except Exception as e:
+    logger.error(f"Post-write manifest verification failed: {e}", exc_info=True)
+    print("❌ Manifest write verification failed. See logs.")
+    return {"status": "error", "message": "Manifest verification failed"}
+
+# After ZIP creation
+if not output_zip.exists() or output_zip.stat().st_size == 0:
+    logger.error(f"ZIP missing or empty: {output_zip}")
+    return {"status": "error", "message": "ZIP creation failed"}
+```
+
+Optional fail-fast for subprocess:
+
+```diff
+-subprocess.run(cmd, capture_output=True, text=True, check=False)
++subprocess.run(cmd, capture_output=True, text=True, check=True)
+```
+
+- Final verdict: ⚠️ Needs Rework
+
+  - Reason: Apply logging handlers/config, add the missing log calls for manifest read and archive failure, and consider post-write/ZIP verification. Current state risks invisible failures and data loss without auditability.
+
+- Confidence score (0–10)
+
+  - 8
+
+- I completed a concise merge-safety review based on the Phase A findings and Phase B validations. Verdict: Needs Rework until logging config and remaining handlers are added, with optional verification hardening for manifest/ZIP.


### PR DESCRIPTION
9 critical fixes applied to 07_finish_project.py:
1. Add logging infrastructure (import + module logger + basicConfig in main)
2. Log run_prezip_stager exceptions with traceback
3. Log cleanup summary failures + surface to user in dry-run
4. Log manifest backup failures + warn user + 3-second pause
5. Log .gitignore update failures
6. Log manifest reload failures after update
7. Log manifest read failures with file name
8. Log archive failures with project ID
9. Configure logging to file + stream (data/file_operations_logs/finish_project.log)

Phase C verdict: Needs Rework (8/10) - All silent failures now visible

Also added TODO:
- Automate Raptor review workflow using ChatGPT + Claude API endpoints

Result: Zero audit trail → full logging + user warnings for all error paths

🦖 RAPTOR AUDIT COMPLETE! 8/8 scripts reviewed and hardened!

## PR Summary

- Title: <concise, action-oriented>
- Branch: <feature/..., fix/..., chore/...>
- Linked Issue (if any): #

## What Changed
- <≤80-char bullet>
- <≤80-char bullet>
- <≤80-char bullet>

## Commits
- <short-sha> (<full-sha>): <one-line summary>

## Files Touched
- `path/to/file1`
- `path/to/file2`

## How to Verify
1. <exact command or URL>
2. <expected output>
3. <where to look>

## Links
- Direct PR: <this page URL>
- Compare view (optional): https://github.com/<org>/<repo>/compare/main...<branch>

## Reviewer Notes
- Breaking changes? <yes/no>
- Data migration? <yes/no>
- Safety concerns? <yes/no>


