### PR TITLE
Fix deprecated GitHub Actions versions in daily-tests.yml

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -47,7 +47,7 @@ jobs:
           python -m pytest scripts/tests/ --junitxml=test-results/test-results.xml --cov=scripts --cov-report=xml:test-results/coverage.xml
 
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results-${{ github.run_id }}


### PR DESCRIPTION
- Update actions/upload-artifact from v3 to v4 (v3 deprecated April 2024)
- Update actions/setup-python from v4 to v5 for consistency with ci.yml

This fixes the automatic failure of daily test runs due to deprecated action.

## PR Summary

- Title: <concise, action-oriented>
- Branch: <feature/..., fix/..., chore/...>
- Linked Issue (if any): #

## What Changed
- <≤80-char bullet>
- <≤80-char bullet>
- <≤80-char bullet>

## Commits
- <short-sha> (<full-sha>): <one-line summary>

## Files Touched
- `path/to/file1`
- `path/to/file2`

## How to Verify
1. <exact command or URL>
2. <expected output>
3. <where to look>

## Links
- Direct PR: <this page URL>
- Compare view (optional): https://github.com/<org>/<repo>/compare/main...<branch>

## Reviewer Notes
- Breaking changes? <yes/no>
- Data migration? <yes/no>
- Safety concerns? <yes/no>


