### PR TITLE
Fix CodeQL info exposure: remove exception details from responses

### DIFF
--- a/scripts/01_ai_assisted_reviewer.py
+++ b/scripts/01_ai_assisted_reviewer.py
@@ -732,12 +732,13 @@ def perform_file_operations(
                 "deleted_images": 1,
                 "message": f"Rejected: {selected_image.name} moved to delete staging",
             }
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to reject single image")
             return {
                 "moved_selected": 0,
                 "moved_crop": 0,
                 "deleted_images": 0,
-                "message": f"Error: {e}",
+                "message": "Error: Failed to reject image",
             }
 
     if selected_index is None:
@@ -834,12 +835,13 @@ def perform_file_operations(
         }
         return result
 
-    except Exception as e:
+    except Exception:
+        logger.exception("Error during file operations")
         return {
             "moved_selected": 0,
             "moved_crop": 0,
             "deleted_images": 0,
-            "message": f"Error during file operations: {e}",
+            "message": "Error during file operations",
         }
 
 

--- a/scripts/06_web_duplicate_finder.py
+++ b/scripts/06_web_duplicate_finder.py
@@ -746,10 +746,9 @@ def create_app(left_dir, right_dir):
                         _ = safe_delete_image_and_yaml(
                             source_path, hard_delete=False, tracker=tracker
                         )
-                    except Exception as e:
-                        errors.append(
-                            f"send2trash not available or delete failed for {image}: {e}"
-                        )
+                    except Exception:
+                        logger.exception(f"Delete failed for {image}")
+                        errors.append(f"Delete failed for {image}")
                         continue
 
                     # Log training data for duplicate detection


### PR DESCRIPTION
- scripts/01_ai_assisted_reviewer.py: Replace str(e) with generic error messages in perform_file_operations return values
- scripts/06_web_duplicate_finder.py: Remove exception details from error messages appended to errors list

Exception details are now logged via logger.exception() for debugging while user-facing messages remain generic.

## PR Summary

- Title: <concise, action-oriented>
- Branch: <feature/..., fix/..., chore/...>
- Linked Issue (if any): #

## What Changed
- <≤80-char bullet>
- <≤80-char bullet>
- <≤80-char bullet>

## Commits
- <short-sha> (<full-sha>): <one-line summary>

## Files Touched
- `path/to/file1`
- `path/to/file2`

## How to Verify
1. <exact command or URL>
2. <expected output>
3. <where to look>

## Links
- Direct PR: <this page URL>
- Compare view (optional): https://github.com/<org>/<repo>/compare/main...<branch>

## Reviewer Notes
- Breaking changes? <yes/no>
- Data migration? <yes/no>
- Safety concerns? <yes/no>


