### PR TITLE
Fix daily-tests.yml: add missing project dependencies

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov ruff mypy pyyaml selenium pillow matplotlib requests webdriver-manager flask send2trash
 
       - name: Create test data directory
         run: mkdir -p data/test_data


### PR DESCRIPTION
The daily test suite was failing with exit code 3 because it only installed pytest/pytest-cov but was missing all the actual project dependencies (pyyaml, pillow, send2trash, etc.) that the tests need to import. Added the same dependency list used in ci.yml.

## PR Summary

- Title: <concise, action-oriented>
- Branch: <feature/..., fix/..., chore/...>
- Linked Issue (if any): #

## What Changed
- <≤80-char bullet>
- <≤80-char bullet>
- <≤80-char bullet>

## Commits
- <short-sha> (<full-sha>): <one-line summary>

## Files Touched
- `path/to/file1`
- `path/to/file2`

## How to Verify
1. <exact command or URL>
2. <expected output>
3. <where to look>

## Links
- Direct PR: <this page URL>
- Compare view (optional): https://github.com/<org>/<repo>/compare/main...<branch>

## Reviewer Notes
- Breaking changes? <yes/no>
- Data migration? <yes/no>
- Safety concerns? <yes/no>


