### PR TITLE
fix: add workflow permissions for reusable workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,24 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  claude-review:
+    uses: eriksjaastad/tools/.github/workflows/claude-review-reusable.yml@main
+    with:
+      test_command: |
+        if uv run -m pytest --collect-only -q 2>/dev/null | grep -q "test"; then
+          uv run -m pytest --tb=short -q
+        else
+          echo "No tests found, skipping"
+        fi
+      review_style: governance
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_GITHUB_API_KEY }}


### PR DESCRIPTION
Fixes startup_failure on CI review. Repos with default read-only token permissions need explicit permissions in the caller workflow.